### PR TITLE
GH-93 - Checking for target parentNode instead of the target node itself...

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -145,7 +145,7 @@ function addEventListeners (target, component) {
       // handler is triggered on it.
       var current = e.target;
 
-      while (current && current !== document && current !== target) {
+      while (current && current !== document && current !== target.parentNode) {
         if (matchesSelector.call(current, delegate)) {
           return handler(target, e, current);
         }

--- a/test/unit/events.js
+++ b/test/unit/events.js
@@ -18,6 +18,22 @@ describe('Events', function () {
     expect(numTriggered).to.equal(1);
   });
 
+  it('should bind to the component element', function () {
+    var numTriggered = 0;
+    var Div = skate('div', {
+      events: {
+        'test div' : function () {
+          ++numTriggered;
+        }
+      }
+    });
+
+    var div = new Div();
+
+    helpers.dispatchEvent('test', div);
+    expect(numTriggered).to.equal(1);
+  });
+
   it('should allow you to re-add the element back into the DOM', function () {
     var numTriggered = 0;
     var Div = skate('div', {


### PR DESCRIPTION
... to allow binding events to the component element

Added a simple test that binds an event to the component element and mocks an event.
