### PR TITLE
Wait for DOM ready before initialising pre existing elements

### DIFF
--- a/src/skate.js
+++ b/src/skate.js
@@ -19,9 +19,19 @@ import version from './version';
  * @returns {undefined}
  */
 var initDocument = debounce(function () {
-  document.addEventListener('DOMContentLoaded', function initialiseSkateElementsOnDomLoad() {
+  if (hasDomContentLoadedFired) {
     initElements(document.getElementsByTagName('html'));
-  });
+  } else {
+    document.addEventListener('DOMContentLoaded', function initialiseSkateElementsOnDomLoad() {
+      initElements(document.getElementsByTagName('html'));
+    });
+  }
+});
+
+var hasDomContentLoadedFired = false;
+
+document.addEventListener('DOMContentLoaded', function () {
+  hasDomContentLoadedFired = true;
 });
 
 /**

--- a/src/skate.js
+++ b/src/skate.js
@@ -14,24 +14,18 @@ import version from './version';
 
 /**
  * Initialises all valid elements in the document. Ensures that it does not
- * happen more than once in the same execution.
+ * happen more than once in the same execution, and that it happens after the DOM is ready.
  *
  * @returns {undefined}
  */
 var initDocument = debounce(function () {
-  if (hasDomContentLoadedFired) {
-    initElements(document.getElementsByTagName('html'));
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    initElements(document.documentElement.childNodes);
   } else {
     document.addEventListener('DOMContentLoaded', function initialiseSkateElementsOnDomLoad() {
-      initElements(document.getElementsByTagName('html'));
+      initElements(document.documentElement.childNodes);
     });
   }
-});
-
-var hasDomContentLoadedFired = false;
-
-document.addEventListener('DOMContentLoaded', function () {
-  hasDomContentLoadedFired = true;
 });
 
 /**

--- a/src/skate.js
+++ b/src/skate.js
@@ -19,7 +19,9 @@ import version from './version';
  * @returns {undefined}
  */
 var initDocument = debounce(function () {
-  initElements(document.getElementsByTagName('html'));
+  document.addEventListener('DOMContentLoaded', function initialiseSkateElementsOnDomLoad() {
+    initElements(document.getElementsByTagName('html'));
+  });
 });
 
 /**


### PR DESCRIPTION
There was inconsistent behaviour when this occurred in the <head> script tag, due to the debounce providing a timeout.

This caused problems in IE (sometimes execution was slow enough that by the time the timeout was complete, the DOM was still not ready.)