### PR TITLE
Default extends prop (empty str) is not a valid tag name (#119).

### DIFF
--- a/src/skate.js
+++ b/src/skate.js
@@ -184,7 +184,7 @@ skate.defaults = {
 
   // Restricts a particular definition to binding explicitly to an element with
   // a tag name that matches the specified value.
-  extends: '',
+  extends: undefined,
 
   // The ID of the definition. This is automatically set in the `skate()`
   // function.


### PR DESCRIPTION
Fixes #119.