### PR TITLE
Fix failing tests in IE9, 10, and 11

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -15,13 +15,23 @@ import {
 } from './utils';
 
 var elProto = window.HTMLElement.prototype;
-var matchesSelector = (
+var nativeMatchesSelector = (
   elProto.matches ||
   elProto.msMatchesSelector ||
   elProto.webkitMatchesSelector ||
   elProto.mozMatchesSelector ||
   elProto.oMatchesSelector
 );
+// Only IE9 has this msMatchesSelector bug, but best to detect it.
+var hasNativeMatchesSelectorDetattachedBug = !nativeMatchesSelector.call(document.createElement('div'), 'div');
+var matchesSelector = function (element, selector) {
+  if (hasNativeMatchesSelectorDetattachedBug) {
+    var clone = element.cloneNode();
+    document.createElement('div').appendChild(clone);
+    return nativeMatchesSelector.call(clone, selector);
+  }
+  return nativeMatchesSelector.call(element, selector);
+};
 
 /**
  * Parses an event definition and returns information about it.
@@ -228,7 +238,7 @@ function addEventListeners (target, component) {
       var current = e.target;
 
       while (current && current !== document && current !== target.parentNode) {
-        if (matchesSelector.call(current, delegate)) {
+        if (matchesSelector(current, delegate)) {
           return handler(target, e, current);
         }
 

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -244,6 +244,18 @@ MutationObserver.prototype = {
       attributeHandler: function (e) {
         var eTarget = e.target;
 
+        if (!(e.relatedNode instanceof Attr)) {
+          // IE10 fires two mutation events for attributes, one with the
+          // target as the relatedNode, and one where it's the attribute.
+          //
+          // Re: relatedNode, "In the case of the DOMAttrModified event
+          // it indicates the Attr node which was modified, added, or
+          // removed." [1]
+          //
+          // [1]: https://msdn.microsoft.com/en-us/library/ff943606%28v=vs.85%29.aspx
+          return;
+        }
+
         if (!canTriggerAttributeModification(eTarget)) {
           return;
         }

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -306,14 +306,14 @@ describe('Attribute listeners', function () {
             ++called;
           }
         };
+        nonFallbackHandlers.forEach(function (item) {
+          testHandlers[item] = function () {};
+        });
+
         var MyEl = skate(tagName.safe, {
           attributes: {
             test: testHandlers
           }
-        });
-
-        nonFallbackHandlers.forEach(function (item) {
-          testHandlers[item] = function () {};
         });
 
         var myEl = new MyEl();

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -15,7 +15,7 @@ describe('Attribute listeners', function () {
         }
       });
 
-      new MyEl().getAttribute('test').should.equal('true');
+      expect(new MyEl().getAttribute('test')).to.equal('true');
     });
 
     it('should allow a callback to return a default value', function () {
@@ -30,7 +30,7 @@ describe('Attribute listeners', function () {
         }
       });
 
-      new MyEl().getAttribute('test').should.equal('true');
+      expect(new MyEl().getAttribute('test')).equal('true');
     });
 
     it('should not override if already specified', function () {
@@ -44,11 +44,11 @@ describe('Attribute listeners', function () {
         }
       });
 
-      skate.init(helpers.fixture('<my-el test="false"></my-el>', tagName))
-        .firstChild
-        .test
-        .should
-        .equal('false');
+      expect(
+        skate.init(helpers.fixture('<my-el test="false"></my-el>', tagName))
+          .firstChild
+          .test
+      ).to.equal('false');
     });
   });
 
@@ -99,27 +99,27 @@ describe('Attribute listeners', function () {
     });
 
     it('should respect attributes that are already camel-cased', function () {
-      myEl.camelCased.should.equal('true');
+      expect(myEl.camelCased).to.equal('true');
     });
 
     it('should camel-case the property name and leave the attribute name as is', function () {
-      myEl.notCamelCased.should.equal('true');
+      expect(myEl.notCamelCased).to.equal('true');
     });
 
     it('should set the attribute when the property is set', function () {
       myEl.setAttribute('test-proxy', false);
-      myEl.testProxy.should.equal('false');
+      expect(myEl.testProxy).to.equal('false');
     });
 
     it('should set the property when the attribute is set', function () {
       myEl.testProxy = true;
-      myEl.getAttribute('test-proxy').should.equal('true');
+      expect(myEl.getAttribute('test-proxy')).to.equal('true');
     });
 
     it('should call created after setting the default value', function (done) {
       helpers.afterMutations(function () {
-        myEl.testCreated.should.equal('true');
-        created.should.equal(true);
+        expect(myEl.testCreated).to.equal('true');
+        expect(created).to.equal(true);
         done();
       });
     });
@@ -127,8 +127,8 @@ describe('Attribute listeners', function () {
     it('should call created when the attribute is set for the first time', function (done) {
       myEl.testLifecycle = true;
       helpers.afterMutations(function () {
-        myEl.testLifecycle.should.equal('true');
-        created.should.equal(true);
+        expect(myEl.testLifecycle).to.equal('true');
+        expect(created).to.equal(true);
         done();
       });
     });
@@ -137,7 +137,7 @@ describe('Attribute listeners', function () {
       myEl.testLifecycle = true;
       myEl.testLifecycle = false;
       helpers.afterMutations(function () {
-        updated.should.equal(true);
+        expect(updated).to.equal(true);
         done();
       });
     });
@@ -146,7 +146,7 @@ describe('Attribute listeners', function () {
       myEl.testLifecycle = true;
       myEl.testLifecycle = undefined;
       helpers.afterMutations(function () {
-        removed.should.equal(true);
+        expect(removed).to.equal(true);
         done();
       });
     });
@@ -154,7 +154,7 @@ describe('Attribute listeners', function () {
     it('should not override an existing property', function (done) {
       myEl.setAttribute('override', 'false');
       helpers.afterMutations(function () {
-        myEl.override.should.equal('true');
+        expect(myEl.override).to.equal('true');
         done();
       });
     });
@@ -167,14 +167,14 @@ describe('Attribute listeners', function () {
           test: {
             created: function (element, data) {
               expect(data.oldValue).to.equal(null);
-              data.newValue.should.equal('created');
+              expect(data.newValue).to.equal('created');
             },
             updated: function (element, data) {
-              data.oldValue.should.equal('created');
-              data.newValue.should.equal('updated');
+              expect(data.oldValue).to.equal('created');
+              expect(data.newValue).to.equal('updated');
             },
             removed: function (element, data) {
-              data.oldValue.should.equal('updated');
+              expect(data.oldValue).to.equal('updated');
               expect(data.newValue).to.equal(null);
               done();
             }
@@ -242,12 +242,12 @@ describe('Attribute listeners', function () {
           test: function (element, data) {
             if (data.type === 'created') {
               expect(data.oldValue).to.equal(null);
-              data.newValue.should.equal('created');
+              expect(data.newValue).to.equal('created');
             } else if (data.type === 'updated') {
-              data.oldValue.should.equal('created');
-              data.newValue.should.equal('updated');
+              expect(data.oldValue).to.equal('created');
+              expect(data.newValue).to.equal('updated');
             } else if (data.type === 'removed') {
-              data.oldValue.should.equal('updated');
+              expect(data.oldValue).to.equal('updated');
               expect(data.newValue).to.equal(null);
               done();
             }
@@ -275,12 +275,12 @@ describe('Attribute listeners', function () {
 
           if (data.type === 'created') {
             expect(data.oldValue).to.equal(null);
-            data.newValue.should.equal('created');
+            expect(data.newValue).to.equal('created');
           } else if (data.type === 'updated') {
-            data.oldValue.should.equal('created');
-            data.newValue.should.equal('updated');
+            expect(data.oldValue).to.equal('created');
+            expect(data.newValue).to.equal('updated');
           } else if (data.type === 'removed') {
-            data.oldValue.should.equal('updated');
+            expect(data.oldValue).to.equal('updated');
             expect(data.newValue).to.equal(null);
             done();
           }
@@ -323,7 +323,7 @@ describe('Attribute listeners', function () {
           helpers.afterMutations(function () {
             myEl.test = undefined;
             helpers.afterMutations(function () {
-              called.should.equal(expectedNumCalls);
+              expect(called).to.equal(expectedNumCalls);
               done();
             });
           });
@@ -377,8 +377,8 @@ describe('Attribute listeners', function () {
       });
 
       skate.init(helpers.fixture('<my-el first></my-el>', tagName));
-      document.querySelector(tagName.safe).hasAttribute('first').should.equal(true);
-      document.querySelector(tagName.safe).hasAttribute('second').should.equal(false);
+      expect(document.querySelector(tagName.safe).hasAttribute('first')).to.equal(true);
+      expect(document.querySelector(tagName.safe).hasAttribute('second')).to.equal(false);
     });
 
     it('should iterate over every attribute even if one removed while it is still being processed', function () {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -300,7 +300,7 @@ describe('Attribute listeners', function () {
     describe('should allow a fallback callback to be specified that catches all changes (same as passing a function instead of an object)', function () {
       function assertAttributeLifeycleCalls(expectedNumCalls, nonFallbackHandlers, done) {
         var called = 0;
-        var tagName = helpers.safeTagName('my-el');
+        var {safe: tagName} = helpers.safeTagName('my-el');
         var testHandlers = {
           fallback: function () {
             ++called;
@@ -310,7 +310,7 @@ describe('Attribute listeners', function () {
           testHandlers[item] = function () {};
         });
 
-        var MyEl = skate(tagName.safe, {
+        var MyEl = skate(tagName, {
           attributes: {
             test: testHandlers
           }

--- a/test/unit/init.js
+++ b/test/unit/init.js
@@ -47,13 +47,13 @@ describe('Synchronous initialisation', function () {
 
 describe('Instantiation', function () {
   it('should return a constructor', function () {
-    skate('div', {}).should.be.a('function');
+    expect(skate('div', {})).to.be.a('function');
   });
 
   it('should return a new element when constructed.', function () {
     var Div = skate('div', {});
     var div = new Div();
-    div.nodeName.should.equal('DIV');
+    expect(div.nodeName).to.equal('DIV');
   });
 
   it('should synchronously initialise the new element.', function () {
@@ -67,7 +67,7 @@ describe('Instantiation', function () {
     });
 
     new Div().someMethod();
-    called.should.equal(true);
+    expect(called).to.equal(true);
   });
 
   it('should call lifecycle callbacks at appropriate times.', function (done) {
@@ -87,20 +87,20 @@ describe('Instantiation', function () {
     });
 
     var div = new Div();
-    created.should.equal(true, 'Should call created');
-    attached.should.equal(false, 'Should not call attached');
-    detached.should.equal(false, 'Should not call detached');
+    expect(created).to.equal(true, 'Should call created');
+    expect(attached).to.equal(false, 'Should not call attached');
+    expect(detached).to.equal(false, 'Should not call detached');
 
     document.body.appendChild(div);
     skate.init(div);
-    attached.should.equal(true, 'Should call attached');
-    detached.should.equal(false, 'Should not call remove');
+    expect(attached).to.equal(true, 'Should call attached');
+    expect(detached).to.equal(false, 'Should not call remove');
 
     div.parentNode.removeChild(div);
 
     // Mutation Observers are async.
     setTimeout(function () {
-      detached.should.equal(true, 'Should call detached');
+      expect(detached).to.equal(true, 'Should call detached');
       done();
     }, 1);
   });

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -36,8 +36,8 @@ describe('Returning a constructor', function () {
     expect(div.func1).to.be.a('function');
     expect(div.func2).to.be.a('function');
 
-    div.func1.should.equal(Div.prototype.func1);
-    div.func2.should.equal(Div.prototype.func2);
+    expect(div.func1).to.equal(Div.prototype.func1);
+    expect(div.func2).to.equal(Div.prototype.func2);
   });
 
   it('should not allow the constructor property to be enumerated.', function () {
@@ -61,8 +61,8 @@ describe('Returning a constructor', function () {
 
     var div = new Div();
 
-    div.func1.should.be.a('function');
-    div.func2.should.be.a('function');
+    expect(div.func1).to.be.a('function');
+    expect(div.func2).to.be.a('function');
   });
 
   it('should allow the overwriting of the prototype', function () {
@@ -74,7 +74,7 @@ describe('Returning a constructor', function () {
 
     var div = new Div();
 
-    div.func.should.be.a('function');
+    expect(div.func).to.be.a('function');
   });
 
   it('should allow getters and setters on the prototype', function () {

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -30,7 +30,7 @@ describe('Registry', function () {
     var element = document.createElement('test1');
 
     element.setAttribute('test2', '');
-    element.classList.add('test3');
+    element.className += ' test3';
 
     registry.set('test1', definition1);
     registry.set('test2', definition2);

--- a/test/unit/version.js
+++ b/test/unit/version.js
@@ -5,6 +5,6 @@ import skate from '../../src/skate';
 
 describe('version', function () {
   it('should be exposed', function () {
-    skate.version.should.be.a('string');
+    expect(skate.version).to.be.a('string');
   });
 });


### PR DESCRIPTION
Fixes #154.

There are currently still failures across all three browsers due to timeouts before the `done()` callback is called in the tests:

```text
IE 11.0.0 (Windows 7) DOM General DOM node interaction. should pick up descendants that are detached if an ancestor's innerHTML is set. FAILED
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
IE 10.0.0 (Windows 7) DOM General DOM node interaction. should pick up descendants that are detached if an ancestor's innerHTML is set. FAILED
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
IE 9.0.0 (Windows 7) DOM General DOM node interaction. should pick up descendants that are detached if an ancestor's innerHTML is set. FAILED
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
IE 9.0.0 (Windows 7) DOM General DOM node interaction. should pick up descendants that are detached if an ancestor is detached. FAILED
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
IE 10.0.0 (Windows 7) DOM General DOM node interaction. should pick up descendants that are detached if an ancestor is detached. FAILED
	timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```