### PR TITLE
Move triggering of attribute created callbacks to after the created lifecycle callback is triggered.

### DIFF
--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -185,10 +185,11 @@ export default function (options) {
     patchAttributeMethods(element, options);
     addAttributeToPropertyLinks(element, options);
     initAttributes(element, options);
-    triggerAttributesCreated(element, options);
 
     if (options.created) {
       options.created(element);
     }
+
+    triggerAttributesCreated(element, options);
   };
 }

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -162,10 +162,10 @@ export default function (options) {
 
     // Native custom elements automatically inherit the prototype. We apply
     // the user defined prototype directly to the element instance if not.
-    // Note that in order to catch modified prototype chains - such as when
-    // setPrototypeOf() or ES6 classes are used - we must walk each prototype
-    // and apply each member directly.
-    if (!options.isNative) {
+    // Skate will always add lifecycle callbacks to the definition. If native
+    // custom elements are being used, one of these will already be on the
+    // element. If not, then we are initialising via non-native means.
+    if (!element.attributeChangedCallback) {
       getPrototypes(options.prototype).forEach(function (proto) {
         if (!proto.isPrototypeOf(element)) {
           assign(element, proto);

--- a/test/unit/init.js
+++ b/test/unit/init.js
@@ -189,13 +189,15 @@ describe('skate.init()', function () {
       it(`type "${type}", extending "${tagToExtend}"`, function () {
         var calls = 0;
         var callsPerCreationType = {};
-        var {safe: tagName} = helpers.safeTagName('my-element');
+        var { safe: tagName } = helpers.safeTagName();
+
         skate(tagName, {
           type: type,
           extends: tagToExtend,
           created: function () {
             ++calls;
-          }
+          },
+          gagas: true
         });
 
         var el1 = document.createElement(tagName);

--- a/test/unit/init.js
+++ b/test/unit/init.js
@@ -196,8 +196,7 @@ describe('skate.init()', function () {
           extends: tagToExtend,
           created: function () {
             ++calls;
-          },
-          gagas: true
+          }
         });
 
         var el1 = document.createElement(tagName);


### PR DESCRIPTION
Fixes #179.

Also fixes tests in browsers that support native custom elements by checking if we should apply the prototype at runtime in a different way. 