### PR TITLE
Modularise binding types

### DIFF
--- a/src/api/type.js
+++ b/src/api/type.js
@@ -1,11 +1,98 @@
-import {
-  TYPE_ATTRIBUTE,
-  TYPE_CLASSNAME,
-  TYPE_ELEMENT
-} from '../constants';
+function getClassList (element) {
+  var classList = element.classList;
+
+  if (classList) {
+    return classList;
+  }
+
+  var attrs = element.attributes;
+
+  return (attrs['class'] && attrs['class'].nodeValue.split(/\s+/)) || [];
+}
 
 export default {
-  ATTRIBUTE: TYPE_ATTRIBUTE,
-  CLASSNAME: TYPE_CLASSNAME,
-  ELEMENT: TYPE_ELEMENT
+  ATTRIBUTE: {
+    create (opts) {
+      var elem = document.createElement(opts.extends || 'div');
+      elem.setAttribute(opts.id, '');
+      return elem;
+    },
+    find (elem, defs) {
+      var attrs = elem.attributes;
+      var attrsLen = attrs.length;
+      var definitions = [];
+      var tag = elem.tagName.toLowerCase();
+
+      for (let a = 0; a < attrsLen; a++) {
+        let attr = attrs[a].nodeName;
+        let definition = defs[attr];
+
+        if (definition && definition.type === this) {
+          let tagToExtend = definition.extends;
+          if (!tagToExtend || tag === tagToExtend) {
+            definitions.push(definition);
+          }
+        }
+      }
+
+      return definitions;
+    }
+  },
+  CLASSNAME: {
+    create (opts) {
+      var elem = document.createElement(opts.extends || 'div');
+      elem.className = opts.id;
+      return elem;
+    },
+    find (elem, defs) {
+      var classList = getClassList(elem);
+      var classListLen = classList.length;
+      var definitions = [];
+      var tag = elem.tagName.toLowerCase();
+
+      for (let a = 0; a < classListLen; a++) {
+        let className = classList[a];
+        let definition = defs[className];
+
+        if (definition && definition.type === this) {
+          let tagToExtend = definition.extends;
+          if (!tagToExtend || tag === tagToExtend) {
+            definitions.push(definition);
+          }
+        }
+      }
+
+      return definitions;
+    }
+  },
+  ELEMENT: {
+    /* jshint expr: true */
+    create (opts) {
+      var elem = document.createElement(opts.extends || opts.id);
+      opts.extends && elem.setAttribute('is', opts.id);
+      return elem;
+    },
+    find (elem, defs) {
+      var attrs = elem.attributes;
+      var definitions = [];
+      var isAttr = attrs.is;
+      var isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
+      var tag = elem.tagName.toLowerCase();
+      var definition = defs[isAttrValue || tag];
+
+      if (definition && definition.type === this) {
+        let tagToExtend = definition.extends;
+
+        if (isAttrValue) {
+          if (tag === tagToExtend) {
+            definitions.push(definition);
+          }
+        } else if (!tagToExtend) {
+          definitions.push(definition);
+        }
+      }
+
+      return definitions;
+    }
+  }
 };

--- a/src/api/type.js
+++ b/src/api/type.js
@@ -1,3 +1,5 @@
+import binding from '../polyfill/binding';
+
 function getClassList (element) {
   var classList = element.classList;
 
@@ -65,34 +67,5 @@ export default {
       return definitions;
     }
   },
-  ELEMENT: {
-    /* jshint expr: true */
-    create (opts) {
-      var elem = document.createElement(opts.extends || opts.id);
-      opts.extends && elem.setAttribute('is', opts.id);
-      return elem;
-    },
-    find (elem, defs) {
-      var attrs = elem.attributes;
-      var definitions = [];
-      var isAttr = attrs.is;
-      var isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
-      var tag = elem.tagName.toLowerCase();
-      var definition = defs[isAttrValue || tag];
-
-      if (definition && definition.type === this) {
-        let tagToExtend = definition.extends;
-
-        if (isAttrValue) {
-          if (tag === tagToExtend) {
-            definitions.push(definition);
-          }
-        } else if (!tagToExtend) {
-          definitions.push(definition);
-        }
-      }
-
-      return definitions;
-    }
-  }
+  ELEMENT: binding
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,0 @@
-export const ATTR_IGNORE = 'data-skate-ignore';
-export const TYPE_ATTRIBUTE = 'attribute';
-export const TYPE_CLASSNAME = 'classname';
-export const TYPE_ELEMENT = 'element';

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,4 +1,4 @@
-import { TYPE_ELEMENT } from './constants';
+import apiType from './api/type';
 
 export default {
   // Called when the element is attached to the document.
@@ -35,7 +35,7 @@ export default {
   template: undefined,
 
   // The type of bindings to allow.
-  type: TYPE_ELEMENT,
+  type: apiType.ELEMENT,
 
   // The attribute name to remove after calling the created() callback.
   unresolvedAttribute: 'unresolved'

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,4 +1,4 @@
-import apiType from './api/type';
+import binding from './polyfill/binding';
 
 export default {
   // Called when the element is attached to the document.
@@ -35,7 +35,7 @@ export default {
   template: undefined,
 
   // The type of bindings to allow.
-  type: apiType.ELEMENT,
+  type: binding,
 
   // The attribute name to remove after calling the created() callback.
   unresolvedAttribute: 'unresolved'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { TYPE_ELEMENT } from './constants';
 import apiChain from './api/chain';
 import apiCreate from './api/create';
 import apiEmit from './api/emit';
@@ -74,12 +73,11 @@ var debouncedInitDocumentWhenReady = debounce(initDocumentWhenReady);
 var HTMLElement = window.HTMLElement;
 
 function skate (id, userOptions) {
-  var Ctor, CtorParent, isElement, isNative;
+  var Ctor, CtorParent, isNative;
   var options = makeOptions(userOptions);
 
   CtorParent = options.extends ? document.createElement(options.extends).constructor : HTMLElement;
-  isElement = options.type === TYPE_ELEMENT;
-  isNative = isElement && supportsCustomElements() && validCustomElement(id);
+  isNative = options.type === apiType.ELEMENT && supportsCustomElements() && validCustomElement(id);
 
   // Inherit from parent prototype.
   if (!CtorParent.prototype.isPrototypeOf(options.prototype)) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import defaults from './defaults';
 import detached from './lifecycle/detached';
 import documentObserver from './polyfill/document-observer';
 import elementConstructor from './polyfill/element-constructor';
+import polyfillBinding from './polyfill/binding';
 import registry from './polyfill/registry';
 import supportsCustomElements from './support/custom-elements';
 import walkTree from './util/walk-tree';
@@ -77,7 +78,7 @@ function skate (id, userOptions) {
   var options = makeOptions(userOptions);
 
   CtorParent = options.extends ? document.createElement(options.extends).constructor : HTMLElement;
-  isNative = options.type === apiType.ELEMENT && supportsCustomElements() && validCustomElement(id);
+  isNative = options.type === polyfillBinding && supportsCustomElements() && validCustomElement(id);
 
   // Inherit from parent prototype.
   if (!CtorParent.prototype.isPrototypeOf(options.prototype)) {

--- a/src/polyfill/binding.js
+++ b/src/polyfill/binding.js
@@ -1,0 +1,30 @@
+export default {
+  /* jshint expr: true */
+  create (opts) {
+    var elem = document.createElement(opts.extends || opts.id);
+    opts.extends && elem.setAttribute('is', opts.id);
+    return elem;
+  },
+  find (elem, defs) {
+    var attrs = elem.attributes;
+    var definitions = [];
+    var isAttr = attrs.is;
+    var isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
+    var tag = elem.tagName.toLowerCase();
+    var definition = defs[isAttrValue || tag];
+
+    if (definition && definition.type === this) {
+      let tagToExtend = definition.extends;
+
+      if (isAttrValue) {
+        if (tag === tagToExtend) {
+          definitions.push(definition);
+        }
+      } else if (!tagToExtend) {
+        definitions.push(definition);
+      }
+    }
+
+    return definitions;
+  }
+};

--- a/src/polyfill/element-constructor.js
+++ b/src/polyfill/element-constructor.js
@@ -1,34 +1,13 @@
-import {
-  TYPE_ATTRIBUTE,
-  TYPE_CLASSNAME,
-  TYPE_ELEMENT
-} from '../constants';
-
-const DEFAULT_ELEMENT = 'div';
+import bindings from '../api/type';
 
 function createElement (options) {
-  var element;
-  var id = options.id;
-  var parent = options.extends;
   var type = options.type;
-
-  // Allow all types of components to be constructed.
-  if (type === TYPE_ELEMENT) {
-    element = document.createElement(parent || id);
-    if (parent) {
-      element.setAttribute('is', id);
-    }
-  } else {
-    element = document.createElement(parent || DEFAULT_ELEMENT);
-
-    if (type === TYPE_ATTRIBUTE) {
-      element.setAttribute(id, '');
-    } else if (type === TYPE_CLASSNAME) {
-      element.className = id;
+  for (let a in bindings) {
+    let binding = bindings[a];
+    if (type === binding) {
+      return binding.create(options);
     }
   }
-
-  return element;
 }
 
 export default function (options) {

--- a/src/polyfill/registry.js
+++ b/src/polyfill/registry.js
@@ -1,97 +1,27 @@
-import {
-  TYPE_ATTRIBUTE,
-  TYPE_CLASSNAME,
-  TYPE_ELEMENT
-} from '../constants';
-
+import bindings from '../api/type';
 import globals from '../globals';
 import hasOwn from '../util/has-own';
-
-function getClassList (element) {
-  var classList = element.classList;
-
-  if (classList) {
-    return classList;
-  }
-
-  var attrs = element.attributes;
-
-  return (attrs['class'] && attrs['class'].nodeValue.split(/\s+/)) || [];
-}
 
 export default globals.registerIfNotExists('registry', {
   definitions: {},
 
-  get: function (id) {
+  get (id) {
     return hasOwn(this.definitions, id) && this.definitions[id];
   },
 
-  set: function (id, definition) {
-    if (hasOwn(this.definitions, id)) {
-      throw new Error('A component definition of type "' + definition.type + '" with the ID of "' + id + '" already exists.');
+  set (id, definition) {
+    if (this.get(id)) {
+      throw new Error(`A Skate component with the name of "${id}" already exists.`);
     }
     this.definitions[id] = definition;
     return this;
   },
 
-  isType: function (id, type) {
-    var def = this.get(id);
-    return def && def.type === type;
-  },
-
-  getForElement: function (element) {
-    var attrs = element.attributes;
-    var attrsLen = attrs.length;
-    var definitions = [];
-    var isAttr = attrs.is;
-    var isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
-    var tag = element.tagName.toLowerCase();
-    var isAttrOrTag = isAttrValue || tag;
-    var definition;
-    var tagToExtend;
-
-    if (this.isType(isAttrOrTag, TYPE_ELEMENT)) {
-      definition = this.definitions[isAttrOrTag];
-      tagToExtend = definition.extends;
-
-      if (isAttrValue) {
-        if (tag === tagToExtend) {
-          definitions.push(definition);
-        }
-      } else if (!tagToExtend) {
-        definitions.push(definition);
-      }
+  getForElement (elem) {
+    var defs = [];
+    for (let a in bindings) {
+      defs = defs.concat(bindings[a].find(elem, this.definitions) || []);
     }
-
-    for (var a = 0; a < attrsLen; a++) {
-      var attr = attrs[a].nodeName;
-
-      if (this.isType(attr, TYPE_ATTRIBUTE)) {
-        definition = this.definitions[attr];
-        tagToExtend = definition.extends;
-
-        if (!tagToExtend || tag === tagToExtend) {
-          definitions.push(definition);
-        }
-      }
-    }
-
-    var classList = getClassList(element);
-    var classListLen = classList.length;
-
-    for (var b = 0; b < classListLen; b++) {
-      var className = classList[b];
-
-      if (this.isType(className, TYPE_CLASSNAME)) {
-        definition = this.definitions[className];
-        tagToExtend = definition.extends;
-
-        if (!tagToExtend || tag === tagToExtend) {
-          definitions.push(definition);
-        }
-      }
-    }
-
-    return definitions;
+    return defs;
   }
 });

--- a/src/util/ignored.js
+++ b/src/util/ignored.js
@@ -1,6 +1,4 @@
-import { ATTR_IGNORE } from '../constants';
-
 export default function (element) {
   var attrs = element.attributes;
-  return attrs && !!attrs[ATTR_IGNORE];
+  return attrs && !!attrs['data-skate-ignore'];
 }

--- a/test/perf/inserting-elements.js
+++ b/test/perf/inserting-elements.js
@@ -7,7 +7,7 @@ describe('inserting elements', function () {
 
   function benchFn () {
     var div = document.createElement('div');
-    var fix = this.args.fixture
+    var fix = this.args.fixture;
 
     // We're actually testing this, but...
     fix.appendChild(div);
@@ -19,14 +19,27 @@ describe('inserting elements', function () {
     fix.removeChild(div);
   }
 
+  function createMutationObservers (num) {
+    var obs = [];
+    for (let a = 0; a < num; a++) {
+      obs.push(new window.MutationObserver(function () {}));
+      obs[a].observe(document, {
+        childList: true,
+        subtree: true
+      });
+    }
+    return obs;
+  }
+
   beforeEach(function () {
     args = {
+      createMutationObservers: createMutationObservers,
       documentObserver: documentObserver,
       fixture: helpers.fixture()
     };
   });
 
-  bench('(no document observer)', function () {
+  bench('(no observers)', function () {
     return {
       args: args,
       fn: benchFn,
@@ -36,7 +49,49 @@ describe('inserting elements', function () {
     };
   });
 
-  bench('(registered document observer)', function () {
+  bench('(one mutation observer that does nothing)', function () {
+    return {
+      args: args,
+      fn: benchFn,
+      setup: function () {
+        this.args.documentObserver.unregister();
+        this.mutationObservers = this.args.createMutationObservers(1);
+      },
+      teardown: function () {
+        this.mutationObservers.forEach(obs => obs.disconnect());
+      }
+    };
+  });
+
+  bench('(two mutation observers that do nothing)', function () {
+    return {
+      args: args,
+      fn: benchFn,
+      setup: function () {
+        this.args.documentObserver.unregister();
+        this.mutationObservers = this.args.createMutationObservers(2);
+      },
+      teardown: function () {
+        this.mutationObservers.forEach(obs => obs.disconnect());
+      }
+    };
+  });
+
+  bench('(ten mutation observers that do nothing)', function () {
+    return {
+      args: args,
+      fn: benchFn,
+      setup: function () {
+        this.args.documentObserver.unregister();
+        this.mutationObservers = this.args.createMutationObservers(10);
+      },
+      teardown: function () {
+        this.mutationObservers.forEach(obs => obs.disconnect());
+      }
+    };
+  });
+
+  bench('(skate document observer that interrogates elements)', function () {
     return {
       args: args,
       fn: benchFn,

--- a/test/unit/api/init.js
+++ b/test/unit/api/init.js
@@ -220,13 +220,13 @@ describe('api/init', function () {
     }
 
     describe(':', function () {
-      assertType('element', skate.type.ELEMENT,   [1, 0, 0, 0]);
+      assertType('element',   skate.type.ELEMENT,   [1, 0, 0, 0]);
       assertType('attribute', skate.type.ATTRIBUTE, [0, 0, 1, 0]);
       assertType('classname', skate.type.CLASSNAME, [0, 0, 0, 1]);
-      assertType('element', skate.type.ELEMENT,   [0, 1, 0, 0], 'div');
+      assertType('element',   skate.type.ELEMENT,   [0, 1, 0, 0], 'div');
       assertType('attribute', skate.type.ATTRIBUTE, [0, 0, 1, 0], 'div');
       assertType('classname', skate.type.CLASSNAME, [0, 0, 0, 1], 'div');
-      assertType('element', skate.type.ELEMENT,   [0, 0, 0, 0], 'span');
+      assertType('element',   skate.type.ELEMENT,   [0, 0, 0, 0], 'span');
       assertType('attribute', skate.type.ATTRIBUTE, [0, 0, 0, 0], 'span');
       assertType('classname', skate.type.CLASSNAME, [0, 0, 0, 0], 'span');
 

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -29,8 +29,8 @@ describe('Registry', function () {
     definitions = registry.getForElement(element);
 
     expect(definitions.length).to.equal(3);
-    expect(definitions[0]).to.equal(definition1);
-    expect(definitions[1]).to.equal(definition2);
-    expect(definitions[2]).to.equal(definition3);
+    expect(definitions).to.contain(definition1, 'element');
+    expect(definitions).to.contain(definition2, 'attribute');
+    expect(definitions).to.contain(definition3, 'classname');
   });
 });


### PR DESCRIPTION
The idea behind this is that it gives us the ability to pull out unnecessary binding types at a later point. I think it's really worth considering only having the w3c compat spec as the only binding type by default but have the ability to add in custom ones. This way we could remove legacy support for older components as we see fit without affecting backward compatibility in Skate after 1.0.

Some things addressed as part of this:

- Added perf tests for different number of mutation observers on the page and their impact on performance.
- Removed constants file as it's not necessary.