### PR TITLE
add example for installing with jspm

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Or NPM:
 
     npm install skatejs
 
+Or JSPM:
+
+    jspm install npm:skatejs
+
 Include either `dist/skate.js` or `dist/skate.min.js`.
 
 


### PR DESCRIPTION
[jspm](https://github.com/jspm) seems like the way forward for ES6 package management, so I've added an example for installing skate using jspm in the readme, which is similar to npm's example but requires the `npm:` prefix, which could potentially trip up newcomers.