### PR TITLE
Bugfix for <object> tag edge case usage

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -382,7 +382,9 @@ function initElements (elements) {
       triggerLifecycle(element, currentNodeDefinitions[b]);
     }
 
-    var elementChildNodes = element.childNodes;
+    // When <object> tag is used to expose NPAPI api to js may have different behaviour then other
+    // tags. One of those differences is that it's childNodes can be undefined.
+    var elementChildNodes = element.childNodes || [];
     var elementChildNodesLen = elementChildNodes.length;
 
     if (elementChildNodesLen) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -47,7 +47,10 @@ export default {
     var definitions = [];
     var isAttr = attrs.is;
     var isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
-    var tag = element.tagName.toLowerCase();
+
+    // Using localName as fallback for edge cases when processing <object> tag that is used
+    // as inteface to NPAPI plugin.
+    var tag = (element.tagName || element.localName).toLowerCase();
     var isAttrOrTag = isAttrValue || tag;
     var definition;
     var tagToExtend;


### PR DESCRIPTION
skate.js will fail to resolve `element.tagName` and `element.childNodes` in rare cases when processing `object` tag that is used to expose NPAPI plugin inteface to js.

![screen shot 2015-07-21 at 12 08 56](https://cloud.githubusercontent.com/assets/347650/8798673/90740a92-2fac-11e5-8962-04da3a8ce968.png)