### PR TITLE
#260 - changing wording of tag line and sync benefits between docs and frontpage

### DIFF
--- a/docs/src/docs/index.html
+++ b/docs/src/docs/index.html
@@ -4,11 +4,9 @@ template: index.html
 
 <sk-docs-layout>
   <h2 id="h2-what-is-skate">What is Skate?</h2>
-  <p>Skate is a library designed to be an easy-to-use, minimal and performant foundation for building modular and reusable web components. It's built on the philosophy that all libraries should be focused on doing one thing well and therefore makes no assumptions about things better left to other libraries such as templating, data-binding and routing. It can be used standalone or along-side your framework of choice.</p>
+  <p>Skate provides an API to bind behaviours to DOM elements. It's based on the W3C specification for  <a href="http://w3c.github.io/webcomponents/spec/custom/">Custom Elements</a>.</p>
 
-
-
-  <h3>Custom Elements</h3>
+  <h3 id="custom-elements-header">Custom Elements</h3>
 
   <p>Skate uses the <a href="http://w3c.github.io/webcomponents/spec/custom/">W3C Custom Element Spec</a> as the basis for defining its functionality and extends it to make it easier for you to build new custom elements as well as transition your legacy components to custom elements.</p>
   <p>Custom elements are just normal HTML elements that you give a custom name and functionality to:</p>
@@ -18,4 +16,13 @@ template: index.html
       <todo-item>Feed cats</todo-item>
     </todo-list>
   </noscript>
+
+  <h3> Why should you use it?</h3>
+  <ul>
+    <li>Skate is small: 5kb minified and gzipped.</li>
+    <li>Built and measured to perform under extreme circumstances, even in IE.</li>
+    <li>Helps keep you focused and productive while making your code clear and expressive.</li>
+    <li>Easily transition from selector-based behaviour binding to element binding.</li>
+  </ul>
+
 </sk-docs-layout>

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -11,7 +11,7 @@ reveal: true
       </div>
       <div class="col-md-10">
         <h1>SkateJS <span class="badge badge-default"><gh-version repo="skatejs/skatejs"><fa-spin></fa-spin></gh-version></span></h1>
-        <p>Skate is a web component library based on the custom element spec. It's focused on being a tiny, performant, syntactic-sugar for binding behaviour to elements, attributes and classes using a consistent, simple and declarative API.</p>
+        <p>Skate provides an API to bind behaviours to DOM elements. It's based on the W3C specification for  <a href="http://w3c.github.io/webcomponents/spec/custom/">Custom Elements</a>.</p>
       </div>
     </div>
   </div>
@@ -68,17 +68,17 @@ reveal: true
       <div>
         <h3>Tiny</h3>
         <p><bs-icon from="bs" type="scale" class="fa-flip-horizontal"></bs-icon></p>
-        <p>Embrace the technology of tomorrow without tipping the scales of today.</p>
+        <p>Skate is small: 5kb minified and gzipped.</p>
       </div>
       <div>
         <h3>Fast</h3>
         <p><bs-icon type="tachometer"></bs-icon></p>
-        <p>Built to perform under extreme circumstances, even in IE.</p>
+        <p>Built and measured to perform under extreme circumstances, even in IE.</p>
       </div>
       <div>
         <h3>Simple</h3>
         <p><bs-icon from="bs" type="ice-lolly-tasted"></bs-icon></p>
-        <p>Helps keep you focused and productive while making your code clear and expressive.</p>
+        <p>Helps keep you focused and productive while making your code clear and expressive</p>
       </div>
       <div>
         <h3>Compatible</h3>
@@ -87,7 +87,7 @@ reveal: true
           <bs-icon type="tablet"></bs-icon>
           <bs-icon type="laptop"></bs-icon>
         </p>
-        <p>All browsers. All devices. IE9+.</p>
+        <p>Easily transition from selector-based behaviour binding to element binding.</p>
       </div>
     </sk-grid>
   </div>


### PR DESCRIPTION
I synced up the benefits on the front page with the benefits listed on the issue and on the docs subpage. In doing so I've had to remove some of the other benefits that were on the front page  like browser compatibility. Let me know if you think these are still important to put on the front page or we can find somewhere else to put them too.

Main thinking behind this is to make sure the docs and front page are in sync, it's better to have a consistent message across pages IMO.