### PR TITLE
Fixed rare issue with components initialization

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -14,6 +14,7 @@ import {
   objEach
 } from './utils';
 
+var {Node} = window;
 var elProto = window.HTMLElement.prototype;
 var nativeMatchesSelector = (
   elProto.matches ||
@@ -367,12 +368,14 @@ function triggerLifecycle (target, component) {
  * @returns {undefined}
  */
 function initElements (elements) {
-  var elementsLen = elements.length;
-
-  for (var a = 0; a < elementsLen; a++) {
+  // [CATION] Browsers that don't support custom-elements natively in very rare cases won't
+  // trigger mutation observer event on subtree changes when component add siblings on `attached`
+  // lifecycle hook. This could lead to issue with components initialization placed at the end
+  // of childNodes list because they will be out of range of cached length value.
+  for (var a = 0; a < elements.length; a++) {
     var element = elements[a];
 
-    if (element.nodeType !== 1 || element.attributes[ATTR_IGNORE]) {
+    if (element.nodeType !== Node.ELEMENT_NODE || element.attributes[ATTR_IGNORE]) {
       continue;
     }
 
@@ -403,12 +406,11 @@ function initElements (elements) {
  * @returns {undefined}
  */
 function removeElements (elements) {
-  var len = elements.length;
-
-  for (var a = 0; a < len; a++) {
+  // Don't cache `childNodes` length. For more info see description in `initElements` function.
+  for (var a = 0; a < elements.length; a++) {
     var element = elements[a];
 
-    if (element.nodeType !== 1) {
+    if (element.nodeType !== Node.ELEMENT_NODE) {
       continue;
     }
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -368,10 +368,10 @@ function triggerLifecycle (target, component) {
  * @returns {undefined}
  */
 function initElements (elements) {
-  // [CATION] Browsers that don't support custom-elements natively in very rare cases won't
-  // trigger mutation observer event on subtree changes when component add siblings on `attached`
-  // lifecycle hook. This could lead to issue with components initialization placed at the end
-  // of childNodes list because they will be out of range of cached length value.
+  // [CATION] Don't cache elements length! Components initialization could append nodes
+  // as siblings (see label's element behaviour for example) and this could lead to problems with
+  // components placed at the end of processing childNodes because they will change they index
+  // position and get out of cached value range.
   for (var a = 0; a < elements.length; a++) {
     var element = elements[a];
 

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -7,7 +7,7 @@ import {
   objEach
 } from './utils';
 
-var Attr = window.Attr;
+var {Node, Attr} = window;
 var NativeMutationObserver = window.MutationObserver || window.WebkitMutationObserver || window.MozMutationObserver;
 var isFixingIe = false;
 var isIe = window.navigator.userAgent.indexOf('Trident') > -1;
@@ -158,7 +158,7 @@ MutationObserver.prototype = {
       //
       // IE 11 bug: https://connect.microsoft.com/IE/feedback/details/817132/ie-11-childnodes-are-missing-from-mutationobserver-mutations-removednodes-after-setting-innerhtml
       var shouldWorkAroundIeRemoveBug = isFixingIe && eType === 'DOMNodeRemoved';
-      var isDescendant = lastBatchedElement && lastBatchedElement.nodeType === 1 && elementContains(lastBatchedElement, eTarget);
+      var isDescendant = lastBatchedElement && lastBatchedElement.nodeType === Node.ELEMENT_NODE && elementContains(lastBatchedElement, eTarget);
 
       // This checks to see if the element is contained in the last batched
       // element. If it is, then we don't batch it because elements are


### PR DESCRIPTION
Found today problem with rendering simple DOM tree in browsers that doesn't support custom-elements natively (all except Google Chrome).

DOM tree example
```xml
<component1>
	<section class="some-class"></section>
	<section class="some-class2">
		<component2 id="id1">
			<content>
				Some content
			</content>
		</component2>
		<span></span>
		<component2 id="id2">
			<content>
				Some content
			</content>
		</component2>
		<span></span>
		<component2 id="id3">
			<content>
				Some content
			</content>
		</component2>
	</section>
</component1>
```

Last `<component2>` node that was not initialized after appending to document. Problem was with `MutationObserver` shim that was not firing event on appending child nodes to `section.some-class2`.

I was trying to recreate issue in tests with simple DOM manipulations but with no luck. `MutationObserver` shim was working properly.

So here is a list of circumstances that could lead to this problem:

1. `<component2>` on `attached` callback moves some child nodes to `component2.nextSibling`. This behaviour is similar to `<label>` element that move inappropriate elements away.
1. Around 100+ components and subcomponents are rendering on the page at the same time.
1. Components' content renders with [virtual-dom](https://github.com/Matt-Esch/virtual-dom) lib.
1. Changes to document are made in batches with using [fastdom](https://github.com/wilsonpage/fastdom) lib.

P.S. I will continue my attempts to reproduce this problem in tests. But for now i wasn't be able to do this

---

I guess my problem is related with [this](https://github.com/skatejs/skatejs/blob/0.13.x/src/mutation-observer.js#L183) line of code that can lead to increasing [elements length](https://github.com/skatejs/skatejs/blob/0.13.x/src/lifecycle.js#L370). Need to investigate... maybe there should be another fix...

---

If i am right the problem is in [this](https://github.com/skatejs/skatejs/blob/0.13.x/src/mutation-observer.js#L217) line of code. Because `MutationObserver` callback is synchronously fired before cleaning `lastBatchedRecord` this could lead to adding other nodes exactly like in case i faced today. Native MutationObserver callbacks are fired at the "end of micro-task" (there is a good explanation in [this](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/) article) and i am afraid can't be achieved properly with `setTimeout`. Only promises behave same way but that is not an option for browsers that does not have support for them.

Will make another fix tomorrow.