### PR TITLE
Make getClosestIgnoredElement iFrame-safe

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -84,7 +84,8 @@ export function debounce (fn) {
 export function getClosestIgnoredElement (element) {
   var parent = element;
 
-  while (parent && parent !== document && !(parent instanceof DocumentFragment)) {
+  // e.g. document doesn't have a function hasAttribute; no need to go further up
+  while (parent && typeof parent.hasAttribute === 'function' && !(parent instanceof DocumentFragment)) {
     if (parent.hasAttribute(ATTR_IGNORE)) {
       return parent;
     }


### PR DESCRIPTION
When skate is included in an iframe it still may receive events from the parent-document if they share domain. Then ```document``` will refer to the iframe's document while climbing up parentNodes will lead us to the parent-document's document