### PR TITLE
Fix missing ignore section in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,15 @@
   "version": "0.13.11",
   "author": "Trey Shugart <treshugart@gmail.com> (http://treshugart.github.io)",
   "repository": "git@github.com:skatejs/skatejs",
-  "main": "dist/skate.js"
+  "main": "dist/skate.js",
+  "ignore": [
+    "**/.*",
+    "build",
+    "gulpfile.js",
+    "package.json",
+    "perf",
+    "test",
+    "docs",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
This fixes:
`bower invalid-meta  skatejs is missing "ignore" entry in bower.json`

and also prevents downloading unnecessary files & folders