### PR TITLE
#306 - Make getClosestIgnoredElement iFrame-safe

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -85,7 +85,7 @@ export function getClosestIgnoredElement (element) {
   var parent = element;
 
   // e.g. document doesn't have a function hasAttribute; no need to go further up
-  while (parent && typeof parent.hasAttribute === 'function' && !(parent instanceof DocumentFragment)) {
+  while (parent instanceof Element) {
     if (parent.hasAttribute(ATTR_IGNORE)) {
       return parent;
     }

--- a/test/unit.js
+++ b/test/unit.js
@@ -13,4 +13,5 @@ import './unit/lifecycle';
 import './unit/registration';
 import './unit/registry';
 import './unit/templating';
+import './unit/utils';
 import './unit/version';

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,14 @@
+import helpers from '../lib/helpers';
+import { getClosestIgnoredElement } from '../../src/utils';
+
+describe('utils', function () {
+  describe('getClosestIgnoredElement()', function () {
+    it('should not fail called on an element in an iframe', function () {
+      var iframe = document.createElement('iframe');
+      var descendant = document.createElement('div');
+      helpers.fixture().appendChild(iframe);
+      iframe.contentDocument.body.appendChild(descendant);
+      getClosestIgnoredElement(descendant);
+    });
+  });
+});

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,8 +1,6 @@
 import helpers from '../lib/helpers';
 import { getClosestIgnoredElement } from '../../src/utils';
 
-let { Element } = window;
-
 describe('utils', function () {
   describe('getClosestIgnoredElement()', function () {
     it('should not fail called on an element in an iframe', function () {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,6 +1,8 @@
 import helpers from '../lib/helpers';
 import { getClosestIgnoredElement } from '../../src/utils';
 
+let { Element } = window;
+
 describe('utils', function () {
   describe('getClosestIgnoredElement()', function () {
     it('should not fail called on an element in an iframe', function () {


### PR DESCRIPTION
PR that pulls in fix from #306 and updates the check in the `while` loop. Added test to ensure `getClosestIngoreElement()` works for elements in an iframe.