### PR TITLE
Fix overriding prototypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,9 @@ function skate (id, userOptions) {
   // Ensure the ID can be retrieved from the options or constructor.
   opts.id = id;
 
+  // Store the check for a native custom element so we don't need to re-calculate it later.
+  opts.isNative = isNative;
+
   // Make a constructor for the definition.
   if (isNative) {
     Ctor = document.registerElement(id, opts);

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -55,7 +55,7 @@ export default function (opts) {
 
   return function () {
     let info = data(this, opts.id);
-    let isNative = this.createdCallback;
+    let isNative = !this.hasOwnProperty('_isPolyfill') && this.createdCallback || !(this._isPolyfill = true);
     let isResolved = this.hasAttribute(opts.resolvedAttribute);
 
     if (info.created) return;

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -55,7 +55,7 @@ export default function (opts) {
 
   return function () {
     let info = data(this, opts.id);
-    let isNative = this.createdCallback;
+    let isNative = opts.isNative;
     let isResolved = this.hasAttribute(opts.resolvedAttribute);
 
     if (info.created) return;

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -55,7 +55,7 @@ export default function (opts) {
 
   return function () {
     let info = data(this, opts.id);
-    let isNative = !this.hasOwnProperty('_isPolyfill') && this.createdCallback || !(this._isPolyfill = true);
+    let isNative = this.createdCallback;
     let isResolved = this.hasAttribute(opts.resolvedAttribute);
 
     if (info.created) return;

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -104,20 +104,20 @@ describe('Returning a constructor', function () {
   });
 
   it('should merge prototype functions if an element is skated more than once', function () {
-    var tag = helperElement('my-el');
-    var element = document.createElement(tag.safe);
+    var { safe: tagName } = helperElement('my-el');
 
-    skate(tag.safe, {
+    var Element = skate(tagName, {
       prototype: {
         func1:  function () {
           return true;
         }
       }
     });
-    skate.init(element);
 
-    element.setAttribute('test-attr', '');
-    skate('test-attr', {
+    var element = new Element();
+    var { safe: attrName } = helperElement('my-attr');
+    element.setAttribute(attrName, '');
+    skate(attrName, {
       type: typeAttribute,
       prototype: {
         func2:  function () {

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -103,7 +103,7 @@ describe('Returning a constructor', function () {
     expect(called).to.equal(true);
   });
 
-  it('should merge prototype methods if skate is called on an element more than once', function () {
+  it('should merge prototype functions if an element is skated more than once', function () {
     var tag = helperElement('my-el');
     var element = document.createElement(tag.safe);
 

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -103,6 +103,34 @@ describe('Returning a constructor', function () {
     expect(called).to.equal(true);
   });
 
+  it('should merge prototype methods if skate is called on an element more than once', function () {
+    var tag = helperElement('my-el');
+    var element = document.createElement(tag.safe);
+
+    skate(tag.safe, {
+      prototype: {
+        func1:  function () {
+          return true;
+        }
+      }
+    });
+    skate.init(element);
+
+    element.setAttribute('test-attr', '');
+    skate('test-attr', {
+      type: typeAttribute,
+      prototype: {
+        func2:  function () {
+          return true;
+        }
+      }
+    });
+    skate.init(element);
+
+    expect(element.func1).to.be.a('function');
+    expect(element.func2).to.be.a('function');
+  });
+
   describe('when an extends option is specified', function () {
     var Div;
     var div;


### PR DESCRIPTION
This fixes an issue where skating an element more than once would fail to update the prototype after the first time. This happened because the check for `isNative` just checked for the presence of `createdCallback` on the element, which would be set the first time the element was skated.

The solution is to store the result of the first check for `isNative` and use that value instead.