### PR TITLE
Use native callback names.

### DIFF
--- a/src/api/init.js
+++ b/src/api/init.js
@@ -1,5 +1,3 @@
-import attached from '../lifecycle/attached';
-import created from '../lifecycle/created';
 import elementContains from '../util/element-contains';
 import registry from '../global/registry';
 import walkTree from '../util/walk-tree';
@@ -12,12 +10,12 @@ export default function (element) {
     var componentsLength = components.length;
 
     for (let a = 0; a < componentsLength; a++) {
-      created(components[a]).call(descendant);
+      components[a].prototype.createdCallback.call(descendant);
     }
 
     for (let a = 0; a < componentsLength; a++) {
       if (isInDom) {
-        attached(components[a]).call(descendant);
+        components[a].prototype.attachedCallback.call(descendant);
       }
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -52,11 +52,11 @@ var initDocument = debounce(function () {
     var componentsLength = components.length;
 
     for (let a = 0; a < componentsLength; a++) {
-      created(components[a]).call(element);
+      components[a].prototype.createdCallback.call(element);
     }
 
     for (let a = 0; a < componentsLength; a++) {
-      attached(components[a]).call(element);
+      components[a].prototype.attachedCallback.call(element);
     }
   });
 });

--- a/src/lifecycle/attached.js
+++ b/src/lifecycle/attached.js
@@ -11,13 +11,13 @@ function callAttachedOnDescendants (elem, id) {
 }
 
 export default function (opts) {
+  let fnAttached = opts.prototype.attachedCallback || function(){};
   return function () {
     let info = data(this, opts.id);
     if (info.attached) return;
     info.attached = true;
     info.detached = false;
-
     callAttachedOnDescendants(this, opts.id);
-    opts.attached.call(this);
+    fnAttached.call(this);
   };
 }

--- a/src/lifecycle/attribute.js
+++ b/src/lifecycle/attribute.js
@@ -1,7 +1,7 @@
 import data from '../util/data';
 
 export default function (opts) {
-  let callback = opts.attribute || function () {};
+  let callback = opts.prototype.attributeChangedCallback || function () {};
 
   return function (name, oldValue, newValue) {
     let info = data(this);

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -49,10 +49,10 @@ function markAsResolved (elem, resolvedAttribute, unresolvedAttribute) {
 }
 
 export default function (opts) {
-  let created = opts.created;
   let isNative = opts.isNative;
   let prototype = applyPrototype(opts.prototype);
-  let ready = opts.ready;
+  let fnCreated = opts.prototype.createdCallback || function(){};
+  let fnReady = opts.prototype.readyCallback || function(){};
 
   return function () {
     let info = data(this, opts.id);
@@ -65,9 +65,9 @@ export default function (opts) {
     isNative || prototype.call(this);
     properties.call(this, opts.properties);
     events.call(this, opts.events);
-    opts.created && created.call(this);
+    fnCreated.call(this);
     callCreatedOnDescendants(this, opts.id);
-    opts.ready && ready.call(this);
+    fnReady.call(this);
     isResolved || markAsResolved(this, opts.resolvedAttribute, opts.unresolvedAttribute);
   };
 }

--- a/src/lifecycle/detached.js
+++ b/src/lifecycle/detached.js
@@ -11,13 +11,13 @@ function callDetachedOnDescendants (elem, id) {
 }
 
 export default function (opts) {
+  let fnDetached = opts.prototype.detachedCallback || function(){};
   return function () {
     let info = data(this, opts.id);
     if (info.detached) return;
     info.detached = true;
     info.attached = false;
-
     callDetachedOnDescendants(this, opts.id);
-    opts.detached.call(this);
+    fnDetached.call(this);
   };
 }

--- a/test/unit/api/fragment.js
+++ b/test/unit/api/fragment.js
@@ -56,10 +56,10 @@ describe('api/fragment', function () {
       tagName = element().safe;
       var created = 0;
       skate(tagName, {
-        created: function () {
-          // Can't use the "resolved" attr in assertions about the clone since cloning will copy
-          // the attr but not init the cloned element's lifecycle.
-          created++;
+        prototype: {
+          createdCallback () {
+            ++created;
+          }
         }
       });
 
@@ -74,7 +74,7 @@ describe('api/fragment', function () {
       clone.appendChild(el1);
       expect(clone.childNodes.length).to.equal(1);
       expect(resolved(clone.childNodes[0])).to.equal(true);
-    })
+    });
   });
 
   describe('html', function () {

--- a/test/unit/api/init.js
+++ b/test/unit/api/init.js
@@ -6,14 +6,15 @@ import typeClass from 'skatejs-type-class';
 import typeElement from '../../../src/type/element';
 
 describe('api/init', function () {
-  var MyEl;
-  var tagName;
+  let tagName;
 
   beforeEach(function () {
     tagName = helperElement('my-el');
-    MyEl = skate(tagName.safe, {
-      created: function () {
-        this.textContent = 'test';
+    skate(tagName.safe, {
+      prototype: {
+        createdCallback () {
+          this.textContent = 'test';
+        }
       }
     });
 
@@ -30,8 +31,10 @@ describe('api/init', function () {
       var { safe: tagName } = helperElement('div');
 
       skate(tagName, {
-        attached: function () {
-          initialised = true;
+        prototype: {
+          attachedCallback () {
+            initialised = true;
+          }
         }
       });
 
@@ -49,7 +52,11 @@ describe('api/init', function () {
         skate(tagName, {
           type: type,
           extends: tagToExtend,
-          created () { ++calls; }
+          prototype: {
+            createdCallback () {
+              ++calls;
+            }
+          }
         });
 
         calls = 0;
@@ -93,8 +100,10 @@ describe('api/init', function () {
         var {safe: tagName} = helperElement('my-element');
 
         skate(tagName, {
-          created: function () {
-            ++calls;
+          prototype: {
+            createdCallback () {
+              ++calls;
+            }
           }
         });
 
@@ -110,8 +119,10 @@ describe('api/init', function () {
     it('#110 - should initialise forms properly', function () {
       var form = document.createElement('form');
       skate('form', {
-        created: function () {
-          this.initialised = true;
+        prototype: {
+          createdCallback () {
+            this.initialised = true;
+          }
         }
       });
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1,7 +1,4 @@
-'use strict';
-
 import helperElement from '../lib/element';
-import helperFixture from '../lib/fixture';
 import skate from '../../src/index';
 
 describe('lifecycle/attributes', function () {
@@ -11,7 +8,9 @@ describe('lifecycle/attributes', function () {
       var tag = helperElement();
 
       skate(tag.safe, {
-        attribute: (...args) => data = args
+        prototype: {
+          attributeChangedCallback: (...args) => data = args
+        }
       });
 
       var elem = tag.create();
@@ -39,7 +38,9 @@ describe('lifecycle/attributes', function () {
       var tag = helperElement();
 
       skate(tag.safe, {
-        attribute: () => called = true
+        prototype: {
+          attributeChangedCallback: () => called = true
+        }
       });
 
       tag.create();

--- a/test/unit/dom.js
+++ b/test/unit/dom.js
@@ -15,8 +15,10 @@ describe('dom', function () {
 
       skate.init(helperFixture(`<div><${tag}></${tag}></div>`));
       skate(tag, {
-        attached: function () {
-          ++calls;
+        prototype: {
+          attachedCallback () {
+            ++calls;
+          }
         }
       });
 
@@ -31,8 +33,10 @@ describe('dom', function () {
       var tag = helperElement().safe;
 
       skate(tag, {
-        attached: function () {
-          ++calls;
+        prototype: {
+          attachedCallback () {
+            ++calls;
+          }
         }
       });
 
@@ -48,8 +52,10 @@ describe('dom', function () {
       var tag = helperElement().safe;
 
       skate(tag, {
-        attached: function () {
-          ++calls;
+        prototype: {
+          attachedCallback () {
+            ++calls;
+          }
         }
       });
 
@@ -66,8 +72,10 @@ describe('dom', function () {
       var detached = false;
 
       skate(tag, {
-        detached () {
-          detached = true;
+        prototype: {
+          detachedCallback () {
+            detached = true;
+          }
         }
       });
 
@@ -85,8 +93,10 @@ describe('dom', function () {
     it('should pick up descendants that are detached if an ancestor is detached.', function (done) {
       var tag = helperElement().safe;
       skate(tag, {
-        detached: function () {
-          done();
+        prototype: {
+          detachedCallback () {
+            done();
+          }
         }
       });
 
@@ -124,12 +134,13 @@ describe('dom', function () {
       created = false;
       attached = false;
       MyEl = skate(helperElement('my-element').safe, {
-        created: function () {
-          created = true;
-        },
-
-        attached: function () {
-          attached = true;
+        prototype: {
+          createdCallback () {
+            created = true;
+          },
+          attachedCallback () {
+            attached = true;
+          }
         }
       });
       frag = document.createDocumentFragment();

--- a/test/unit/extending.js
+++ b/test/unit/extending.js
@@ -14,11 +14,11 @@ describe('extending', function () {
     Ctor = skate(helperElement().safe, {
       extends: 'div',
       someNonStandardProperty: true,
-      created: function () {
-        this.textContent = 'test';
-      },
-      attribute: function () {},
       prototype: {
+        attributeChangedCallback () {},
+        createdCallback () {
+          this.textContent = 'test';
+        },
         test: true,
         someFunction: function () {}
       }
@@ -64,8 +64,8 @@ describe('extending', function () {
   it('should allow overriding of callbacks', function () {
     if (canResolveSuper) {
       var ExtendedCtor = skate(tag, class extends Ctor {
-        static created() {
-          super.created();
+        createdCallback () {
+          super.createdCallback();
           this.textContent += 'ing';
         }
       });

--- a/test/unit/ignoring.js
+++ b/test/unit/ignoring.js
@@ -10,11 +10,13 @@ describe('ignoring', function () {
   var attached;
   var tag;
   var definition = {
-    created: function () {
-      ++created;
-    },
-    attached: function () {
-      ++attached;
+    prototype: {
+      createdCallback () {
+        ++created;
+      },
+      attachedCallback () {
+        ++attached;
+      }
     }
   };
 

--- a/test/unit/lifecycle-scenarios.js
+++ b/test/unit/lifecycle-scenarios.js
@@ -10,8 +10,10 @@ describe('lifecycle-scenarios', function () {
     var called = false;
 
     skate(el.safe, {
-      created () {
-        called = true;
+      prototype: {
+        createdCallback () {
+          called = true;
+        }
       }
     });
     helperFixture(document.createElement(el.safe));
@@ -34,8 +36,10 @@ describe('lifecycle-scenarios', function () {
 
     helperFixture(el.create());
     skate(el.safe, {
-      created () {
-        called = true;
+      prototype: {
+        createdCallback () {
+          called = true;
+        }
       }
     });
 

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -19,14 +19,16 @@ describe('lifecycle', function () {
     attached = false;
     detached = false;
     MyEl = skate(tagName.safe, {
-      created: function () {
-        created = true;
-      },
-      attached: function () {
-        attached = true;
-      },
-      detached: function () {
-        detached = true;
+      prototype: {
+        createdCallback () {
+          created = true;
+        },
+        attachedCallback () {
+          attached = true;
+        },
+        detachedCallback () {
+          detached = true;
+        }
       }
     });
     myEl = new MyEl();
@@ -73,9 +75,11 @@ describe('unresolved attribute', function () {
   it('should not be considred "resolved" until after ready() is called', function () {
     var tagName = helperElement('my-element');
     skate(tagName.safe, {
-      ready: function () {
-        expect(this.hasAttribute('unresolved')).to.equal(true);
-        expect(this.hasAttribute('resolved')).to.equal(false);
+      prototype: {
+        readyCallback () {
+          expect(this.hasAttribute('unresolved')).to.equal(true);
+          expect(this.hasAttribute('resolved')).to.equal(false);
+        }
       }
     });
 
@@ -85,9 +89,11 @@ describe('unresolved attribute', function () {
   it('should be considred "resolved" after the created lifecycle finishes', function () {
     var tag = helperElement('my-element').safe;
     skate(tag, {
-      created: function () {
-        expect(this.hasAttribute('unresolved')).to.equal(true, 'should have unresolved');
-        expect(this.hasAttribute('resolved')).to.equal(false, 'should not have resolved');
+      prototype: {
+        createdCallback () {
+          expect(this.hasAttribute('unresolved')).to.equal(true, 'should have unresolved');
+          expect(this.hasAttribute('resolved')).to.equal(false, 'should not have resolved');
+        }
       }
     });
 
@@ -109,14 +115,16 @@ describe('lifecycle scenarios', function () {
 
     var { safe: tagName } = helperElement('my-element');
     El = skate(tagName, {
-      created: function () {
-        ++calls.created;
-      },
-      attached: function () {
-        ++calls.attached;
-      },
-      detached: function () {
-        ++calls.detached;
+      prototype: {
+        createdCallback () {
+          ++calls.created;
+        },
+        attachedCallback () {
+          ++calls.attached;
+        },
+        detachedCallback () {
+          ++calls.detached;
+        }
       }
     });
   });
@@ -184,8 +192,10 @@ describe('lifecycle scenarios', function () {
       var attached = 0;
       var def = {
         type: typeAttribute,
-        created: function () { ++created; },
-        attached: function () { ++attached; }
+        prototype: {
+          createdCallback () { ++created; },
+          attachedCallback () { ++attached; }
+        }
       };
 
       skate(id1.safe, def);
@@ -205,14 +215,16 @@ describe('lifecycle scenarios', function () {
       var tag = helperElement('my-el');
 
       skate(tag.safe, {
-        created: function () {
-          created = true;
-        },
-        attached: function () {
-          attached = true;
-        },
-        detached: function () {
-          detached = true;
+        prototype: {
+          createdCallback () {
+            created = true;
+          },
+          attachedCallback () {
+            attached = true;
+          },
+          detachedCallback () {
+            detached = true;
+          }
         }
       });
 
@@ -241,14 +253,16 @@ describe('lifecycle scenarios', function () {
       var numDetached = 0;
       var tag = helperElement('my-el');
       var Element = skate(tag.safe, {
-        created: function () {
-          ++numCreated;
-        },
-        attached: function () {
-          ++numAttached;
-        },
-        detached: function () {
-          ++numDetached;
+        prototype: {
+          createdCallback () {
+            ++numCreated;
+          },
+          attachedCallback () {
+            ++numAttached;
+          },
+          detachedCallback () {
+            ++numDetached;
+          }
         }
       });
 
@@ -284,8 +298,10 @@ describe('lifecycle scenarios', function () {
       idsToSkate.forEach(function (id) {
         skate(id, {
           type: typeClass,
-          created: function () {
-            idsToCheck.push(id);
+          prototype: {
+            createdCallback () {
+              idsToCheck.push(id);
+            }
           }
         });
       });

--- a/test/unit/lifecycle/created.js
+++ b/test/unit/lifecycle/created.js
@@ -12,22 +12,28 @@ describe('lifecycle/created ordering parent -> descendants', function () {
   function createDefinitions () {
     // child requires descendant, so this is first
     skate(`x-descendant-${tag}`, {
-      created () {
-        descendant = ++num;
+      prototype: {
+        createdCallback () {
+          descendant = ++num;
+        }
       }
     });
 
     // host requires child, so this is second
     skate(`x-child-${tag}`, {
-      created () {
-        child = ++num;
+      prototype: {
+        createdCallback () {
+          child = ++num;
+        }
       }
     });
 
     // host has no dependants so it's last
     skate(`x-host-${tag}`, {
-      created () {
-        host = ++num;
+      prototype: {
+        createdCallback () {
+          host = ++num;
+        }
       }
     });
   }

--- a/test/unit/lifecycle/events.js
+++ b/test/unit/lifecycle/events.js
@@ -105,20 +105,20 @@ describe('lifecycle/events', function () {
     var { safe: tagName } = helperElement('my-component');
 
     skate(tagName, {
-      created: function () {
-        this.innerHTML = '<input>';
-      },
-      events: {
-        'blur input': () => blur = true,
-        'focus input': () => focus = true
-      },
       prototype: {
+        createdCallback () {
+          this.innerHTML = '<input>';
+        },
         blur: function () {
           skate.emit(this.querySelector('input'), 'blur');
         },
         focus: function () {
           skate.emit(this.querySelector('input'), 'focus');
         }
+      },
+      events: {
+        'blur input': () => blur = true,
+        'focus input': () => focus = true
       }
     });
 

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -310,9 +310,11 @@ describe('lifecycle/properties', function () {
     let triggered = false;
 
     elem.skate({
-      attribute: function (name) {
-        if (name !== 'resolved' && name !== 'unresolved') {
-          triggered = true;
+      prototype: {
+        attributeChangedCallback: function (name) {
+          if (name !== 'resolved' && name !== 'unresolved') {
+            triggered = true;
+          }
         }
       },
       properties: {
@@ -328,9 +330,11 @@ describe('lifecycle/properties', function () {
     let triggered = false;
 
     elem.skate({
-      attribute: function (name) {
-        if (name !== 'resolved' && name !== 'unresolved') {
-          triggered = true;
+      prototype: {
+        attributeChangedCallback: function (name) {
+          if (name !== 'resolved' && name !== 'unresolved') {
+            triggered = true;
+          }
         }
       },
       properties: {
@@ -345,8 +349,10 @@ describe('lifecycle/properties', function () {
   describe('templating integration', function () {
     it('scenario 1 - DOM mutation', function () {
       skate(elem.safe, {
-        created () {
-          this.innerHTML = `<span>${this.textContent}</span>`;
+        prototype: {
+          createdCallback () {
+            this.innerHTML = `<span>${this.textContent}</span>`;
+          }
         },
         properties: {
           textContent: {
@@ -372,11 +378,13 @@ describe('lifecycle/properties', function () {
       }
 
       skate(elem.safe, {
-        created: render,
         properties: {
           textContent: {
             update: render
           }
+        },
+        prototype: {
+          createdCallback: render
         }
       });
 

--- a/test/unit/lifecycle/ready.js
+++ b/test/unit/lifecycle/ready.js
@@ -9,8 +9,10 @@ describe('lifecycle/ready', function () {
   beforeEach(function () {
     tag = helperElement();
     skate(tag.safe, {
-      ready: function () {
-        this.innerHTML = 'templated';
+      prototype: {
+        readyCallback () {
+          this.innerHTML = 'templated';
+        }
       }
     });
   });
@@ -23,11 +25,13 @@ describe('lifecycle/ready', function () {
   it('should be called after created is called', function () {
     var { safe: tagName } = helperElement('my-el');
     var MyEl = skate(tagName, {
-      created: function () {
-        this.textContent = 'test';
-      },
-      ready: function () {
-        expect(this.textContent).to.equal('test');
+      prototype: {
+        createdCallback () {
+          this.textContent = 'test';
+        },
+        readyCallback () {
+          expect(this.textContent).to.equal('test');
+        }
       }
     });
 
@@ -38,10 +42,13 @@ describe('lifecycle/ready', function () {
     var { safe: tagName } = helperElement('my-el');
     var MyEl = skate(tagName, {
       prototype: {
+        createdCallback () {
+          this.textContent = 'test';
+        },
+        readyCallback () {
+          expect(this.myfunc).to.be.a('function');
+        },
         myfunc: function () {}
-      },
-      ready: function () {
-        expect(this.myfunc).to.be.a('function');
       }
     });
 
@@ -57,22 +64,28 @@ describe('lifecycle/ready', function () {
     function createDefinitions () {
       // child requires descendant, so this is first
       skate(`x-descendant-${tag}`, {
-        ready () {
-          descendant = ++num;
+        prototype: {
+          readyCallback () {
+            descendant = ++num;
+          }
         }
       });
 
       // host requires child, so this is second
       skate(`x-child-${tag}`, {
-        ready () {
-          child = ++num;
+        prototype: {
+          readyCallback () {
+            child = ++num;
+          }
         }
       });
 
       // host has no dependants so it's last
       skate(`x-host-${tag}`, {
-        ready () {
-          host = ++num;
+        prototype: {
+          readyCallback () {
+            host = ++num;
+          }
         }
       });
     }


### PR DESCRIPTION
There's several reasons behind me spiking this:

1. Make the transition from the spec'd callbacks to Skate as simple as possible.
2. Using `this` inside the callback feels more natural.
3. Simplification and better mind mapping of internals.
4. Skate is now inherently compatible with vanilla `document.registerElement()`.
5. Extending base class definitions is simpler internally.

Changes made are:

- `created` -> `prototype.createdCallback`
- `ready` -> `prototype.readyCallback`
- `attached` -> `prototype.attachedCallback`
- `detached` -> `prototype.detachedCallback`
- `attribute` -> `prototype.attributeChangedCallback`

All callback ordering stays the same.

Obviously, if you pass in a vanilla definition, it will insert them into the Skate lifecycle. However, this shouldn't introduce any breakages into native custom elements since Skate doesn't change the order of the native callbacks. Even the `createdCallback` will behave like native because we don't actually force init descendants until after it's called.

I realise this introduces breaking changes in the names and where you define them, however, I think offering two ways of doing something, even if deprecated, in development versions is not ideal. However, if you guys think we should offer deprecations then maybe we should.