### PR TITLE
Only store isNative on opts if it is not native

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,13 +85,14 @@ function skate (id, userOptions) {
   // Ensure the ID can be retrieved from the options or constructor.
   opts.id = id;
 
-  // Store the check for a native custom element so we don't need to re-calculate it later.
-  opts.isNative = isNative;
-
   // Make a constructor for the definition.
   if (isNative) {
     Ctor = document.registerElement(id, opts);
   } else {
+
+    // Store the check for a native custom element so we don't need to re-calculate it later.
+    opts.isNative = isNative;
+
     Ctor = elementConstructor(opts);
     initDocument();
     documentObserver.register();

--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,11 @@ var initDocument = debounce(function () {
 });
 
 function skate (id, userOptions) {
-  var Ctor, CtorParent, isNative;
+  var Ctor, CtorParent;
   var opts = makeOptions(userOptions);
 
   CtorParent = opts.extends ? document.createElement(opts.extends).constructor : HTMLElement;
-  isNative = opts.type === typeElement && supportsCustomElements() && validCustomElement(id);
+  opts.isNative = opts.type === typeElement && supportsCustomElements() && validCustomElement(id);
 
   // Inherit from parent prototype.
   if (!CtorParent.prototype.isPrototypeOf(opts.prototype)) {
@@ -86,13 +86,12 @@ function skate (id, userOptions) {
   opts.id = id;
 
   // Make a constructor for the definition.
-  if (isNative) {
-    Ctor = document.registerElement(id, opts);
+  if (opts.isNative) {
+    Ctor = document.registerElement(id, {
+      extends: opts.extends || undefined,
+      prototype: opts.prototype
+    });
   } else {
-
-    // Store the check for a native custom element so we don't need to re-calculate it later.
-    opts.isNative = isNative;
-
     Ctor = elementConstructor(opts);
     initDocument();
     documentObserver.register();

--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,6 @@ function skate (id, userOptions) {
     opts.prototype = assignSafe(Object.create(CtorParent.prototype), opts.prototype);
   }
 
-  // Native doesn't like if you pass a falsy value. Must be undefined.
-  opts.extends = opts.extends || undefined;
-
   // Extend behaviour of existing callbacks.
   opts.prototype.createdCallback = created(opts);
   opts.prototype.attachedCallback = attached(opts);


### PR DESCRIPTION
It looks like passing `isNative` as an option to `document.registerElement` was causing weird behaviour (in only some cases).

The solution in this PR is to only store `isNative` in `opts` if the element is non-native.

Fixes #325 