### PR TITLE
Fix leaking property init val

### DIFF
--- a/src/lifecycle/properties.js
+++ b/src/lifecycle/properties.js
@@ -1,3 +1,4 @@
+import assignSafe from '../util/assign-safe';
 import dashCase from '../util/dash-case';
 import data from '../util/data';
 import emit from '../api/emit';
@@ -86,7 +87,7 @@ function property (name, prop) {
   return prop;
 }
 
-function defineProperty (elem, name, prop = {}) {
+function defineProperty (elem, name, properties = {}) {
   let initialValue;
   let info = data(elem);
 
@@ -94,9 +95,7 @@ function defineProperty (elem, name, prop = {}) {
     info.attributeToPropertyMap = {};
   }
 
-  if (typeof prop === 'function') {
-    prop = { type: prop };
-  }
+  let prop = typeof properties === 'function' ? { type: properties } : assignSafe({}, properties);
 
   if (prop.attr) {
     if (prop.attr === true) {

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -209,6 +209,32 @@ describe('lifecycle/properties', function () {
     expect(el2.prop1).to.equal('test2');
   });
 
+  it('initial property values should not leak to other elements', function() {
+    let { safe: tagName } = helperElement();
+
+    skate(tagName, {
+      properties: {
+        foo: {
+          attr: true,
+          update: function (value) {
+            this.textContent = value;
+          }
+        }
+      }
+    });
+
+    skate.init(helperFixture(`
+      <${tagName} foo="foo"></${tagName}>
+      <${tagName} foo="bar"></${tagName}>
+      <${tagName}></${tagName}>
+    `));
+
+    let elements = helperFixture().querySelectorAll(tagName);
+    expect(elements[0].textContent).to.equal('foo');
+    expect(elements[1].textContent).to.equal('bar');
+    expect(elements[2].textContent).to.equal('');
+  });
+
   describe('removing attributes when property is set', function () {
     function setup () {
       skate(elem.safe, {
@@ -240,7 +266,7 @@ describe('lifecycle/properties', function () {
       expect(el.hasAttribute('prop1')).to.equal(false);
     });
 
-    it('passing an empty string shoud not remove the linked attribute', function () {
+    it('passing an empty string should not remove the linked attribute', function () {
       let el = setup();
       el.prop1 = '';
       expect(el.getAttribute('prop1')).to.equal('');


### PR DESCRIPTION
Make a deep copy of the properties object before modifying it, to prevent leakage from modifications to the object