### PR TITLE
#335 - Go back to using an argument instead of 'this'

### DIFF
--- a/src/api/init.js
+++ b/src/api/init.js
@@ -1,5 +1,3 @@
-import attached from '../lifecycle/attached';
-import created from '../lifecycle/created';
 import elementContains from '../util/element-contains';
 import registry from '../global/registry';
 import walkTree from '../util/walk-tree';
@@ -12,12 +10,12 @@ export default function (element) {
     var componentsLength = components.length;
 
     for (let a = 0; a < componentsLength; a++) {
-      created(components[a]).call(descendant);
+      components[a].prototype.createdCallback.call(descendant);
     }
 
     for (let a = 0; a < componentsLength; a++) {
       if (isInDom) {
-        attached(components[a]).call(descendant);
+        components[a].prototype.attachedCallback.call(descendant);
       }
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -52,11 +52,11 @@ let initDocument = debounce(function () {
     let componentsLength = components.length;
 
     for (let a = 0; a < componentsLength; a++) {
-      created(components[a]).call(element);
+      components[a].prototype.createdCallback.call(element);
     }
 
     for (let a = 0; a < componentsLength; a++) {
-      attached(components[a]).call(element);
+      components[a].prototype.attachedCallback.call(element);
     }
   });
 });

--- a/src/lifecycle/attached.js
+++ b/src/lifecycle/attached.js
@@ -2,7 +2,8 @@ import data from '../util/data';
 import registry from '../global/registry';
 import walkTree from '../util/walk-tree';
 
-function callAttachedOnDescendants (elem, id) {
+function callAttachedOnDescendants (elem, opts) {
+  let id = opts.id;
   walkTree(elem.childNodes, function (child) {
     registry.find(child).forEach(Ctor => Ctor.prototype.attachedCallback.call(child));
   }, function (child) {
@@ -17,7 +18,7 @@ export default function (opts) {
     info.attached = true;
     info.detached = false;
 
-    callAttachedOnDescendants(this, opts.id);
-    opts.attached.call(this);
+    callAttachedOnDescendants(this, opts);
+    opts.attached(this);
   };
 }

--- a/src/lifecycle/attribute.js
+++ b/src/lifecycle/attribute.js
@@ -7,7 +7,11 @@ export default function (opts) {
     let info = data(this);
     let attributeToPropertyMap = info.attributeToPropertyMap || {};
 
-    callback.call(this, name, oldValue, newValue);
+    callback(this, {
+      name: name,
+      newValue: newValue,
+      oldValue: oldValue
+    });
 
     // Ensure properties are notified of this change. We only do this if we're
     // not already updating the attribute from the property. This is so that

--- a/src/lifecycle/detached.js
+++ b/src/lifecycle/detached.js
@@ -2,7 +2,8 @@ import data from '../util/data';
 import registry from '../global/registry';
 import walkTree from '../util/walk-tree';
 
-function callDetachedOnDescendants (elem, id) {
+function callDetachedOnDescendants (elem, opts) {
+  let id = opts.id;
   walkTree(elem.childNodes, function (child) {
     registry.find(child).forEach(Ctor => Ctor.prototype.detachedCallback.call(child));
   }, function (child) {
@@ -17,7 +18,7 @@ export default function (opts) {
     info.detached = true;
     info.attached = false;
 
-    callDetachedOnDescendants(this, opts.id);
-    opts.detached.call(this);
+    callDetachedOnDescendants(this, opts);
+    opts.detached(this);
   };
 }

--- a/src/lifecycle/events.js
+++ b/src/lifecycle/events.js
@@ -39,6 +39,7 @@ function bindEvent (elem, event, handler) {
   elem.addEventListener(name, handler, capture);
 }
 
-export default function (events) {
-  Object.keys(events).forEach(name => bindEvent(this, name, events[name].bind(this)));
+export default function (elem, opts) {
+  let events = opts.events;
+  Object.keys(events).forEach(name => bindEvent(elem, name, events[name].bind(elem)));
 }

--- a/src/lifecycle/properties.js
+++ b/src/lifecycle/properties.js
@@ -67,7 +67,11 @@ function property (name, prop) {
     // that value. Even if it's not, we use it to reference the old value which
     // is useful information for the setter.
     if (prop.update) {
-      prop.update.call(this, newValue, oldValue);
+      prop.update(this, {
+        name: name,
+        newValue: newValue,
+        oldValue: oldValue
+      });
     }
 
     // If we are emitting notify the element of the change.
@@ -126,6 +130,7 @@ function defineProperty (elem, name, properties = {}) {
   Object.defineProperty(elem, name, prop);
 }
 
-export default function (props) {
-  Object.keys(props).forEach(name => defineProperty(this, name, props[name]));
+export default function (elem, opts) {
+  let props = opts.properties;
+  Object.keys(props).forEach(name => defineProperty(elem, name, props[name]));
 }

--- a/src/lifecycle/render.js
+++ b/src/lifecycle/render.js
@@ -1,6 +1,6 @@
 export default function lifecycleRender (elem, opts) {
   let temp = opts.render;
   if (temp && !elem.hasAttribute(opts.resolvedAttribute)) {
-    temp.call(elem);
+    temp(elem);
   }
 }

--- a/test/unit/api/init.js
+++ b/test/unit/api/init.js
@@ -12,8 +12,8 @@ describe('api/init', function () {
   beforeEach(function () {
     tagName = helperElement('my-el');
     MyEl = skate(tagName.safe, {
-      created: function () {
-        this.textContent = 'test';
+      created: function (elem) {
+        elem.textContent = 'test';
       }
     });
 
@@ -110,8 +110,8 @@ describe('api/init', function () {
     it('#110 - should initialise forms properly', function () {
       var form = document.createElement('form');
       skate('form', {
-        created: function () {
-          this.initialised = true;
+        created: function (elem) {
+          elem.initialised = true;
         }
       });
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1,35 +1,30 @@
-'use strict';
-
 import helperElement from '../lib/element';
-import helperFixture from '../lib/fixture';
 import skate from '../../src/index';
 
-describe('lifecycle/attributes', function () {
+describe('lifecycle/attribute', function () {
   describe('Callback', function () {
     it('should call the callback just like attributeChangedCallback', function () {
       var data;
-      var tag = helperElement();
-
-      skate(tag.safe, {
-        attribute: (...args) => data = args
-      });
-
-      var elem = tag.create();
+      let elem = helperElement().skate({
+        attribute (elem, change) {
+          data = change;
+        }
+      })();
 
       elem.setAttribute('name', 'created');
-      expect(data[0]).to.equal('name');
-      expect(data[1]).to.equal(null);
-      expect(data[2]).to.equal('created');
+      expect(data.name).to.equal('name');
+      expect(data.newValue).to.equal('created');
+      expect(data.oldValue).to.equal(null);
 
       elem.setAttribute('name', 'updated');
-      expect(data[0]).to.equal('name');
-      expect(data[1]).to.equal('created');
-      expect(data[2]).to.equal('updated');
+      expect(data.name).to.equal('name');
+      expect(data.newValue).to.equal('updated');
+      expect(data.oldValue).to.equal('created');
 
       elem.removeAttribute('name');
-      expect(data[0]).to.equal('name');
-      expect(data[1]).to.equal('updated');
-      expect(data[2]).to.equal(null);
+      expect(data.name).to.equal('name');
+      expect(data.newValue).to.equal(null);
+      expect(data.oldValue).to.equal('updated');
     });
   });
 

--- a/test/unit/extending.js
+++ b/test/unit/extending.js
@@ -14,8 +14,8 @@ describe('extending', function () {
     Ctor = skate(helperElement().safe, {
       extends: 'div',
       someNonStandardProperty: true,
-      created: function () {
-        this.textContent = 'test';
+      created: function (elem) {
+        elem.textContent = 'test';
       },
       attribute: function () {},
       prototype: {
@@ -64,9 +64,9 @@ describe('extending', function () {
   it('should allow overriding of callbacks', function () {
     if (canResolveSuper) {
       var ExtendedCtor = skate(tag, class extends Ctor {
-        static created() {
-          super.created();
-          this.textContent += 'ing';
+        static created(elem) {
+          super.created(elem);
+          elem.textContent += 'ing';
         }
       });
       expect(new ExtendedCtor().textContent).to.equal('testing');

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -73,9 +73,9 @@ describe('unresolved attribute', function () {
   it('should not be considred "resolved" until after ready() is called', function () {
     var tagName = helperElement('my-element');
     skate(tagName.safe, {
-      ready: function () {
-        expect(this.hasAttribute('unresolved')).to.equal(true);
-        expect(this.hasAttribute('resolved')).to.equal(false);
+      ready: function (elem) {
+        expect(elem.hasAttribute('unresolved')).to.equal(true);
+        expect(elem.hasAttribute('resolved')).to.equal(false);
       }
     });
 
@@ -85,9 +85,9 @@ describe('unresolved attribute', function () {
   it('should be considred "resolved" after the created lifecycle finishes', function () {
     var tag = helperElement('my-element').safe;
     skate(tag, {
-      created: function () {
-        expect(this.hasAttribute('unresolved')).to.equal(true, 'should have unresolved');
-        expect(this.hasAttribute('resolved')).to.equal(false, 'should not have resolved');
+      created: function (elem) {
+        expect(elem.hasAttribute('unresolved')).to.equal(true, 'should have unresolved');
+        expect(elem.hasAttribute('resolved')).to.equal(false, 'should not have resolved');
       }
     });
 

--- a/test/unit/lifecycle/created.js
+++ b/test/unit/lifecycle/created.js
@@ -9,15 +9,15 @@ describe('lifecycle/created ordering parent -> descendants', function () {
   it('lifecycle feature ordering', function () {
     let order = [];
     helperElement().skate({
-      created () {
+      created (elem) {
         // The prototype should already be set up.
-        this.test();
+        elem.test();
 
         // This event should be triggered at this point.
-        skate.emit(this, 'someNonStandardEvent');
+        skate.emit(elem, 'someNonStandardEvent');
 
         // This should cause "properties" to appear before "created".
-        this.someNonStandardProperty = 'created';
+        elem.someNonStandardProperty = 'created';
 
         // Now push created onto the order stack.
         order.push('created');
@@ -34,18 +34,18 @@ describe('lifecycle/created ordering parent -> descendants', function () {
       },
       properties: {
         someNonStandardProperty: {
-          update (value) {
-            order.push('properties.' + value);
+          update (elem, data) {
+            order.push('properties.' + data.newValue);
           }
         }
       },
-      ready () {
-        this.someNonStandardProperty = 'ready';
+      ready (elem) {
+        elem.someNonStandardProperty = 'ready';
         order.push('ready');
       },
-      render () {
-        skate.emit(this, 'someNonStandardEvent');
-        this.someNonStandardProperty = 'render';
+      render (elem) {
+        skate.emit(elem, 'someNonStandardEvent');
+        elem.someNonStandardProperty = 'render';
         order.push('render');
       }
     })();

--- a/test/unit/lifecycle/events.js
+++ b/test/unit/lifecycle/events.js
@@ -105,8 +105,8 @@ describe('lifecycle/events', function () {
     var { safe: tagName } = helperElement('my-component');
 
     skate(tagName, {
-      created: function () {
-        this.innerHTML = '<input>';
+      created: function (elem) {
+        elem.innerHTML = '<input>';
       },
       events: {
         'blur input': () => blur = true,

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -216,8 +216,8 @@ describe('lifecycle/properties', function () {
       properties: {
         foo: {
           attr: true,
-          update: function (value) {
-            this.textContent = value;
+          update: function (elem, data) {
+            elem.textContent = data.newValue;
           }
         }
       }
@@ -303,8 +303,8 @@ describe('lifecycle/properties', function () {
     let triggered = false;
 
     elem.skate({
-      attribute: function (name) {
-        if (name !== 'resolved' && name !== 'unresolved') {
+      attribute: function (elem, data) {
+        if (data.name === 'test') {
           triggered = true;
         }
       },
@@ -321,8 +321,8 @@ describe('lifecycle/properties', function () {
     let triggered = false;
 
     elem.skate({
-      attribute: function (name) {
-        if (name !== 'resolved' && name !== 'unresolved') {
+      attribute: function (elem, data) {
+        if (data.name === 'test') {
           triggered = true;
         }
       },
@@ -338,13 +338,13 @@ describe('lifecycle/properties', function () {
   describe('templating integration', function () {
     it('scenario 1 - DOM mutation', function () {
       skate(elem.safe, {
-        created () {
-          this.innerHTML = `<span>${this.textContent}</span>`;
+        created (elem) {
+          elem.innerHTML = `<span>${elem.textContent}</span>`;
         },
         properties: {
           textContent: {
-            update (value) {
-              this.querySelector('span').textContent = value;
+            update (elem, data) {
+              elem.querySelector('span').textContent = data.newValue;
             }
           }
         }
@@ -360,8 +360,8 @@ describe('lifecycle/properties', function () {
     });
 
     it('scenario 2 - re-rendering', function () {
-      function render () {
-        this.innerHTML = `<span>${this.textContent}</span>`;
+      function render (elem) {
+        elem.innerHTML = `<span>${elem.textContent}</span>`;
       }
 
       skate(elem.safe, {
@@ -411,10 +411,10 @@ describe('lifecycle/properties', function () {
         elem = helperElement().skate({
           properties: {
             textContent: {
-              update (nv, ov) {
+              update (elem, data) {
                 ++triggered;
-                newValue = nv;
-                oldValue = ov;
+                newValue = data.newValue;
+                oldValue = data.oldValue;
                 order.push('property');
               }
             }
@@ -435,7 +435,7 @@ describe('lifecycle/properties', function () {
         elem();
         expect(triggered).to.equal(1);
         expect(newValue).to.equal('');
-        expect(oldValue).to.equal(undefined);
+        expect(oldValue).to.equal(null);
       });
 
       it('should be called when a property is updated', function () {
@@ -463,8 +463,8 @@ describe('lifecycle/properties', function () {
           properties: {
             test: {
               attr: true,
-              update: function (value) {
-                val = value;
+              update (elem, data) {
+                val = data.newValue;
                 updated = true;
               }
             }
@@ -501,8 +501,8 @@ describe('lifecycle/properties', function () {
             test: {
               attr: true,
               type: Boolean,
-              update: function (value) {
-                val = value;
+              update (elem, data) {
+                val = data.newValue;
                 updated = true;
               }
             }

--- a/test/unit/lifecycle/ready.js
+++ b/test/unit/lifecycle/ready.js
@@ -9,8 +9,8 @@ describe('lifecycle/ready', function () {
   beforeEach(function () {
     tag = helperElement();
     skate(tag.safe, {
-      ready: function () {
-        this.innerHTML = 'templated';
+      ready: function (elem) {
+        elem.innerHTML = 'templated';
       }
     });
   });
@@ -23,11 +23,11 @@ describe('lifecycle/ready', function () {
   it('should be called after created is called', function () {
     var { safe: tagName } = helperElement('my-el');
     var MyEl = skate(tagName, {
-      created: function () {
-        this.textContent = 'test';
+      created: function (elem) {
+        elem.textContent = 'test';
       },
-      ready: function () {
-        expect(this.textContent).to.equal('test');
+      ready: function (elem) {
+        expect(elem.textContent).to.equal('test');
       }
     });
 
@@ -40,8 +40,8 @@ describe('lifecycle/ready', function () {
       prototype: {
         myfunc: function () {}
       },
-      ready: function () {
-        expect(this.myfunc).to.be.a('function');
+      ready: function (elem) {
+        expect(elem.myfunc).to.be.a('function');
       }
     });
 

--- a/test/unit/lifecycle/render.js
+++ b/test/unit/lifecycle/render.js
@@ -62,8 +62,8 @@ describe('lifecycle/render', function () {
   it('should not get called if the resolved attribute is already on the element', function () {
     let called = false;
     elem().skate({
-      created () {
-        this.setAttribute('resolved', '');
+      created (elem) {
+        elem.setAttribute('resolved', '');
       },
       render () {
         called = true;


### PR DESCRIPTION
This implements #335. Changes:

- All functions *not* on the prototype now receive an argument which is the element instead of using `this`. The function is always the first argument.
- The `attribute` callback now receives an object literal as its second argument that contains what was previously the `name`, `newValue` and `oldValue` arguments. This does not conform to native custom elements, however, it's a better design choice for an API because you do not have to remember argument ordering, only names.
- The `properties` callback `update()` now follows the same convention as the `attribute` callback.