### PR TITLE
#302 - Make currentTarget and delegateTarget consistent with jQuery event objects.

### DIFF
--- a/src/lifecycle/events.js
+++ b/src/lifecycle/events.js
@@ -1,5 +1,14 @@
 import matches from '../util/matches-selector';
 
+function readonly (obj, prop, val) {
+  Object.defineProperty(obj, prop, {
+    configurable: true,
+    get () {
+      return val;
+    }
+  });
+}
+
 function parseEvent (e) {
   let parts = e.split(' ');
   let name = parts.shift();
@@ -16,7 +25,8 @@ function makeDelegateHandler (elem, handler, parsed) {
     let selector = parsed.selector;
     while (current && current !== elem.parentNode) {
       if (matches(current, selector)) {
-        e.delegateTarget = current;
+        readonly(e, 'currentTarget', current);
+        readonly(e, 'delegateTarget', elem);
         return handler(e);
       }
       current = current.parentNode;
@@ -26,7 +36,7 @@ function makeDelegateHandler (elem, handler, parsed) {
 
 function makeNormalHandler (elem, handler) {
   return function (e) {
-    e.delegateTarget = elem;
+    readonly(e, 'delegateTarget', elem);
     handler(e);
   };
 }

--- a/test/unit/lifecycle/events.js
+++ b/test/unit/lifecycle/events.js
@@ -75,19 +75,26 @@ describe('lifecycle/events', function () {
   it('should support delegate event selectors', function () {
     skate(tag.safe, {
       events: {
-        'test a': function (e) {
+        test (e) {
           increment();
           expect(this.tagName).to.equal(tag.safe.toUpperCase());
           expect(e.target.tagName).to.equal('SPAN');
           expect(e.currentTarget.tagName).to.equal(tag.safe.toUpperCase());
-          expect(e.delegateTarget.tagName).to.equal('A');
+          expect(e.delegateTarget.tagName).to.equal(tag.safe.toUpperCase());
         },
-        'test span': function (e) {
+        'test a' (e) {
           increment();
           expect(this.tagName).to.equal(tag.safe.toUpperCase());
           expect(e.target.tagName).to.equal('SPAN');
-          expect(e.currentTarget.tagName).to.equal(tag.safe.toUpperCase());
-          expect(e.delegateTarget.tagName).to.equal('SPAN');
+          expect(e.currentTarget.tagName).to.equal('A');
+          expect(e.delegateTarget.tagName).to.equal(tag.safe.toUpperCase());
+        },
+        'test span' (e) {
+          increment();
+          expect(this.tagName).to.equal(tag.safe.toUpperCase());
+          expect(e.target.tagName).to.equal('SPAN');
+          expect(e.currentTarget.tagName).to.equal('SPAN');
+          expect(e.delegateTarget.tagName).to.equal(tag.safe.toUpperCase());
         }
       }
     });
@@ -96,7 +103,7 @@ describe('lifecycle/events', function () {
     helperFixture(inst);
     skate.init(inst);
     skate.emit(inst.querySelector('span'), 'test');
-    expect(numTriggered).to.equal(2);
+    expect(numTriggered).to.equal(3);
   });
 
   it('should support delegate blur and focus events', function () {


### PR DESCRIPTION
Implements #302.