### PR TITLE
chore: fix npm license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Trey Shugart <treshugart@gmail.com> (http://treshugart.github.io)",
   "repository": "git@github.com:skatejs/skatejs",
   "main": "lib/skate.js",
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "babel": "~4.7.0",


### PR DESCRIPTION
Fixes:
```console
npm WARN package.json skatejs@X.X.X No license field.
```