### PR TITLE
test: Add test for MutationObserver polyfill

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -14,3 +14,4 @@ import './unit/registration';
 import './unit/registry';
 import './unit/templating';
 import './unit/version';
+import './unit/mutation-observer';

--- a/test/unit/mutation-observer.js
+++ b/test/unit/mutation-observer.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import helpers from '../lib/helpers';
+import MutationObserverPolyfill from '../../src/mutation-observer';
+
+describe('MutationObserver polyfill', function () {
+
+    it('should detect a mutation', function(done) {
+      let fixture = helpers.fixture();
+
+      fixture.setAttribute('checked','');
+
+      let observer = new MutationObserverPolyfill((mutations) => {
+        expect(mutations.length).to.equal(1);
+        expect(mutations[0].type).to.equal('attributes');
+        expect(mutations[0].oldValue).to.be.null;
+        observer.disconnect();
+        done();
+      });
+
+      observer.observe(fixture, {
+        attributes: true
+      });
+      fixture.removeAttribute('checked');
+    });
+});


### PR DESCRIPTION
This adds a simple test for the MutationObserver - in preparation for automated tests on IE