### PR TITLE
Fix mutation observer / lifecycle management on IE

### DIFF
--- a/src/document-observer.js
+++ b/src/document-observer.js
@@ -5,7 +5,7 @@ import {
   initElements,
   removeElements
 } from './lifecycle';
-import MutationObserver from './mutation-observer';
+import './mutation-observer';
 import {
   getClosestIgnoredElement
 } from './utils';
@@ -48,7 +48,7 @@ function documentObserverHandler (mutations) {
  * @returns {MutationObserver}
  */
 function createDocumentObserver () {
-  var observer = new MutationObserver(documentObserverHandler);
+  var observer = new window.MutationObserver(documentObserverHandler);
 
   // Observe after the DOM content has loaded.
   observer.observe(document, {
@@ -64,7 +64,6 @@ export default {
     // IE has issues with reporting removedNodes correctly. See the polyfill for
     // details. If we fix IE, we must also re-define the document observer.
     if (fixIe) {
-      MutationObserver.fixIe();
       this.unregister();
     }
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -4,7 +4,7 @@ import {
   ATTR_IGNORE
 } from './constants';
 import data from './data';
-import MutationObserver from './mutation-observer';
+import './mutation-observer';
 import registry from './registry';
 import {
   camelCase,
@@ -194,7 +194,7 @@ function addAttributeListeners (target, component) {
     return;
   }
 
-  var observer = new MutationObserver(function (mutations) {
+  var observer = new window.MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
       var name = mutation.attributeName;
       var attr = attrs[name];

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -7,10 +7,8 @@
  * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
- *
- * Modified by Atlassian
  */
-// @version 0.7.2
+// @version 0.7.15
 if (typeof WeakMap === "undefined") {
   (function() {
     var defineProperty = Object.defineProperty;
@@ -48,6 +46,9 @@ if (typeof WeakMap === "undefined") {
 }
 
 (function(global) {
+  if (global.JsMutationObserver) {
+    return;
+  }
   var registrationsTable = new WeakMap();
   var setImmediate;
   if (/Trident|Edge/.test(navigator.userAgent)) {
@@ -343,6 +344,9 @@ if (typeof WeakMap === "undefined") {
     }
   };
   global.JsMutationObserver = JsMutationObserver;
-  if (!global.MutationObserver) global.MutationObserver = JsMutationObserver;
-})(this);
+  if (!global.MutationObserver) {
+    global.MutationObserver = JsMutationObserver;
+    JsMutationObserver._isPolyfilled = true;
+  }
+})(self);
 })(); // Atlassian: added IIFE

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -1,4 +1,4 @@
-(function() { // Atlassian: added IIFE
+(function(self) { // Atlassian: added IIFE
 /**
  * @license
  * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
@@ -349,4 +349,4 @@ if (typeof WeakMap === "undefined") {
     JsMutationObserver._isPolyfilled = true;
   }
 })(self);
-})(); // Atlassian: added IIFE
+})(window); // Atlassian: added IIFE

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -1,313 +1,348 @@
-'use strict';
-
-import {
-  debounce,
-  elementContains,
-  elementPrototype,
-  objEach
-} from './utils';
-
-var {Node, Attr} = window;
-var NativeMutationObserver = window.MutationObserver || window.WebkitMutationObserver || window.MozMutationObserver;
-var isFixingIe = false;
-var isIe = window.navigator.userAgent.indexOf('Trident') > -1;
-
+(function() { // Atlassian: added IIFE
 /**
- * Creates a new mutation record.
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  *
- * @param {Element} target The HTML element that was affected.
- * @param {String} type The type of mutation.
- *
- * @returns {Object}
+ * Modified by Atlassian
  */
-function newMutationRecord (target, type) {
-  return {
-    addedNodes: null,
-    attributeName: null,
-    attributeNamespace: null,
-    nextSibling: null,
-    oldValue: null,
-    previousSibling: null,
-    removedNodes: null,
-    target: target,
-    type: type || 'childList'
-  };
-}
-
-/**
- * Takes an element and recursively saves it's tree structure on each element so
- * that they can be restored later after IE screws things up.
- *
- * @param {Node} node The node to save the tree for.
- *
- * @returns {undefined}
- */
-function walkTree (node, cb) {
-  var childNodes = node.childNodes;
-
-  if (!childNodes) {
-    return;
-  }
-
-  var childNodesLen = childNodes.length;
-
-  for (var a = 0; a < childNodesLen; a++) {
-    var childNode = childNodes[a];
-    cb(childNode);
-    walkTree(childNode, cb);
-  }
-}
-
-// Mutation Observer "Polyfill"
-// ----------------------------
-
-/**
- * This "polyfill" only polyfills what we need for Skate to function. It
- * batches updates and does the bare minimum during synchronous operation
- * which make mutation event performance bearable. The rest is batched on the
- * next tick. Like mutation observers, each mutation is divided into sibling
- * groups for each parent that had mutations. All attribute mutations are
- * batched into separate records regardless of the element they occured on.
- *
- * @param {Function} callback The callback to execute with the mutation info.
- *
- * @returns {undefined}
- */
-function MutationObserver (callback) {
-  if (NativeMutationObserver && !isFixingIe) {
-    return new NativeMutationObserver(callback);
-  }
-
-  this.callback = callback;
-  this.elements = [];
-}
-
-/**
- * IE 11 has a bug that prevents descendant nodes from being reported as removed
- * to a mutation observer in IE 11 if an ancestor node's innerHTML is reset.
- * This same bug also happens when using Mutation Events in IE 9 / 10. Because of
- * this, we must ensure that observers and events get triggered properly on
- * those descendant nodes. In order to do this we have to override `innerHTML`
- * and then manually trigger an event.
- *
- * See: https://connect.microsoft.com/IE/feedback/details/817132/ie-11-childnodes-are-missing-from-mutationobserver-mutations-removednodes-after-setting-innerhtml
- *
- * @returns {undefined}
- */
-MutationObserver.fixIe = function () {
-  // Fix once only if we need to.
-  if (!isIe || isFixingIe) {
-    return;
-  }
-
-  // We have to call the old innerHTML getter and setter.
-  var oldInnerHTML = Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
-
-  // This redefines the innerHTML property so that we can ensure that events
-  // are properly triggered.
-  Object.defineProperty(elementPrototype, 'innerHTML', {
-    get: function () {
-      return oldInnerHTML.get.call(this);
-    },
-    set: function (html) {
-      walkTree(this, function (node) {
-        var mutationEvent = document.createEvent('MutationEvent');
-        mutationEvent.initMutationEvent('DOMNodeRemoved', true, false, null, null, null, null, null);
-        node.dispatchEvent(mutationEvent);
-      });
-
-      oldInnerHTML.set.call(this, html);
-    }
-  });
-
-  // Flag so the polyfill is used for all subsequent Mutation Observer objects.
-  isFixingIe = true;
-};
-
-Object.defineProperty(MutationObserver, 'isFixingIe', {
-  get: function () {
-    return isFixingIe;
-  }
-});
-
-MutationObserver.prototype = {
-  observe: function (target, options) {
-    function addEventToBatch (e) {
-      batchedEvents.push(e);
-      batchEvents();
-    }
-
-    function batchEvent (e) {
-      var eTarget = e.target;
-
-      // In some test environments, e.target has been nulled after the tests
-      // are done and a batch is still processing.
-      if (!eTarget) {
-        return;
-      }
-
-      var eType = e.type;
-      var eTargetParent = eTarget.parentNode;
-
-      if (!canTriggerInsertOrRemove(eTargetParent)) {
-        return;
-      }
-
-      // The same bug that affects IE 11 also affects IE 9 / 10 with Mutation
-      // Events.
-      //
-      // IE 11 bug: https://connect.microsoft.com/IE/feedback/details/817132/ie-11-childnodes-are-missing-from-mutationobserver-mutations-removednodes-after-setting-innerhtml
-      var shouldWorkAroundIeRemoveBug = isFixingIe && eType === 'DOMNodeRemoved';
-      var isDescendant = lastBatchedElement && lastBatchedElement.nodeType === Node.ELEMENT_NODE && elementContains(lastBatchedElement, eTarget);
-
-      // This checks to see if the element is contained in the last batched
-      // element. If it is, then we don't batch it because elements are
-      // batched into first-children of a given parent. However, IE is (of
-      // course) an exception to this and destroys the DOM tree heirarchy
-      // before the callback gets fired if the element was removed. Because of
-      // this, we have to let through all descendants that had the event
-      // triggered on it.
-      if (!shouldWorkAroundIeRemoveBug && isDescendant) {
-        return;
-      }
-
-      if (!lastBatchedRecord || lastBatchedRecord.target !== eTargetParent) {
-        batchedRecords.push(lastBatchedRecord = newMutationRecord(eTargetParent));
-      }
-
-      if (eType === 'DOMNodeInserted') {
-        if (!lastBatchedRecord.addedNodes) {
-          lastBatchedRecord.addedNodes = [];
-        }
-
-        lastBatchedRecord.addedNodes.push(eTarget);
-      } else {
-        if (!lastBatchedRecord.removedNodes) {
-          lastBatchedRecord.removedNodes = [];
-        }
-
-        lastBatchedRecord.removedNodes.push(eTarget);
-      }
-
-      lastBatchedElement = eTarget;
-    }
-
-    function canTriggerAttributeModification (eTarget) {
-      return options.attributes && (options.subtree || eTarget === target);
-    }
-
-    function canTriggerInsertOrRemove (eTargetParent) {
-      return options.childList && (options.subtree || eTargetParent === target);
-    }
-
-    var that = this;
-
-    // Batching insert and remove.
-    var lastBatchedElement;
-    var lastBatchedRecord;
-    var batchedEvents = [];
-    var batchedRecords = [];
-    var batchEvents = debounce(function () {
-        var batchedEventsLen = batchedEvents.length;
-
-        for (var a = 0; a < batchedEventsLen; a++) {
-          batchEvent(batchedEvents[a]);
-        }
-
-        that.callback(batchedRecords);
-        batchedEvents = [];
-        batchedRecords = [];
-        lastBatchedElement = undefined;
-        lastBatchedRecord = undefined;
-      });
-
-    // Batching attributes.
-    var attributeOldValueCache = {};
-    var attributeMutations = [];
-    var batchAttributeMods = debounce(function () {
-      // We keep track of the old length just in case attributes are
-      // modified within a handler.
-      var len = attributeMutations.length;
-
-      // Call the handler with the current modifications.
-      that.callback(attributeMutations);
-
-      // We remove only up to the current point just in case more
-      // modifications were queued.
-      attributeMutations.splice(0, len);
-    });
-
-    var observed = {
-      target: target,
-      options: options,
-      insertHandler: addEventToBatch,
-      removeHandler: addEventToBatch,
-      attributeHandler: function (e) {
-        var eTarget = e.target;
-
-        if (!(e.relatedNode instanceof Attr)) {
-          // IE10 fires two mutation events for attributes, one with the
-          // target as the relatedNode, and one where it's the attribute.
-          //
-          // Re: relatedNode, "In the case of the DOMAttrModified event
-          // it indicates the Attr node which was modified, added, or
-          // removed." [1]
-          //
-          // [1]: https://msdn.microsoft.com/en-us/library/ff943606%28v=vs.85%29.aspx
-          return;
-        }
-
-        if (!canTriggerAttributeModification(eTarget)) {
-          return;
-        }
-
-        var eAttrName = e.attrName;
-        var ePrevValue = e.prevValue;
-        var eNewValue = e.newValue;
-        var record = newMutationRecord(eTarget, 'attributes');
-        record.attributeName = eAttrName;
-
-        if (options.attributeOldValue) {
-          record.oldValue = attributeOldValueCache[eAttrName] || ePrevValue || null;
-        }
-
-        attributeMutations.push(record);
-
-        // We keep track of old values so that when IE incorrectly reports
-        // the old value we can ensure it is actually correct.
-        if (options.attributeOldValue) {
-          attributeOldValueCache[eAttrName] = eNewValue;
-        }
-
-        batchAttributeMods();
+// @version 0.7.2
+if (typeof WeakMap === "undefined") {
+  (function() {
+    var defineProperty = Object.defineProperty;
+    var counter = Date.now() % 1e9;
+    var WeakMap = function() {
+      this.name = "__st" + (Math.random() * 1e9 >>> 0) + (counter++ + "__");
+    };
+    WeakMap.prototype = {
+      set: function(key, value) {
+        var entry = key[this.name];
+        if (entry && entry[0] === key) entry[1] = value; else defineProperty(key, this.name, {
+          value: [ key, value ],
+          writable: true
+        });
+        return this;
+      },
+      get: function(key) {
+        var entry;
+        return (entry = key[this.name]) && entry[0] === key ? entry[1] : undefined;
+      },
+      "delete": function(key) {
+        var entry = key[this.name];
+        if (!entry || entry[0] !== key) return false;
+        entry[0] = entry[1] = undefined;
+        return true;
+      },
+      has: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        return entry[0] === key;
       }
     };
+    window.WeakMap = WeakMap;
+  })();
+}
 
-    this.elements.push(observed);
-
-    if (options.childList) {
-      target.addEventListener('DOMNodeInserted', observed.insertHandler);
-      target.addEventListener('DOMNodeRemoved', observed.removeHandler);
-    }
-
-    if (options.attributes) {
-      target.addEventListener('DOMAttrModified', observed.attributeHandler);
-    }
-
-    return this;
-  },
-
-  disconnect: function () {
-    objEach(this.elements, function (observed) {
-      observed.target.removeEventListener('DOMNodeInserted', observed.insertHandler);
-      observed.target.removeEventListener('DOMNodeRemoved', observed.removeHandler);
-      observed.target.removeEventListener('DOMAttrModified', observed.attributeHandler);
+(function(global) {
+  var registrationsTable = new WeakMap();
+  var setImmediate;
+  if (/Trident|Edge/.test(navigator.userAgent)) {
+    setImmediate = setTimeout;
+  } else if (window.setImmediate) {
+    setImmediate = window.setImmediate;
+  } else {
+    var setImmediateQueue = [];
+    var sentinel = String(Math.random());
+    window.addEventListener("message", function(e) {
+      if (e.data === sentinel) {
+        var queue = setImmediateQueue;
+        setImmediateQueue = [];
+        queue.forEach(function(func) {
+          func();
+        });
+      }
     });
-
-    this.elements = [];
-
-    return this;
+    setImmediate = function(func) {
+      setImmediateQueue.push(func);
+      window.postMessage(sentinel, "*");
+    };
   }
-};
+  var isScheduled = false;
+  var scheduledObservers = [];
+  function scheduleCallback(observer) {
+    scheduledObservers.push(observer);
+    if (!isScheduled) {
+      isScheduled = true;
+      setImmediate(dispatchCallbacks);
+    }
+  }
+  function wrapIfNeeded(node) {
+    return window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrapIfNeeded(node) || node;
+  }
+  function dispatchCallbacks() {
+    isScheduled = false;
+    var observers = scheduledObservers;
+    scheduledObservers = [];
+    observers.sort(function(o1, o2) {
+      return o1.uid_ - o2.uid_;
+    });
+    var anyNonEmpty = false;
+    observers.forEach(function(observer) {
+      var queue = observer.takeRecords();
+      removeTransientObserversFor(observer);
+      if (queue.length) {
+        observer.callback_(queue, observer);
+        anyNonEmpty = true;
+      }
+    });
+    if (anyNonEmpty) dispatchCallbacks();
+  }
+  function removeTransientObserversFor(observer) {
+    observer.nodes_.forEach(function(node) {
+      var registrations = registrationsTable.get(node);
+      if (!registrations) return;
+      registrations.forEach(function(registration) {
+        if (registration.observer === observer) registration.removeTransientObservers();
+      });
+    });
+  }
+  function forEachAncestorAndObserverEnqueueRecord(target, callback) {
+    for (var node = target; node; node = node.parentNode) {
+      var registrations = registrationsTable.get(node);
+      if (registrations) {
+        for (var j = 0; j < registrations.length; j++) {
+          var registration = registrations[j];
+          var options = registration.options;
+          if (node !== target && !options.subtree) continue;
+          var record = callback(options);
+          if (record) registration.enqueue(record);
+        }
+      }
+    }
+  }
+  var uidCounter = 0;
+  function JsMutationObserver(callback) {
+    this.callback_ = callback;
+    this.nodes_ = [];
+    this.records_ = [];
+    this.uid_ = ++uidCounter;
+  }
+  JsMutationObserver.prototype = {
+    observe: function(target, options) {
+      target = wrapIfNeeded(target);
+      if (!options.childList && !options.attributes && !options.characterData || options.attributeOldValue && !options.attributes || options.attributeFilter && options.attributeFilter.length && !options.attributes || options.characterDataOldValue && !options.characterData) {
+        throw new SyntaxError();
+      }
+      var registrations = registrationsTable.get(target);
+      if (!registrations) registrationsTable.set(target, registrations = []);
+      var registration;
+      for (var i = 0; i < registrations.length; i++) {
+        if (registrations[i].observer === this) {
+          registration = registrations[i];
+          registration.removeListeners();
+          registration.options = options;
+          break;
+        }
+      }
+      if (!registration) {
+        registration = new Registration(this, target, options);
+        registrations.push(registration);
+        this.nodes_.push(target);
+      }
+      registration.addListeners();
+    },
+    disconnect: function() {
+      this.nodes_.forEach(function(node) {
+        var registrations = registrationsTable.get(node);
+        for (var i = 0; i < registrations.length; i++) {
+          var registration = registrations[i];
+          if (registration.observer === this) {
+            registration.removeListeners();
+            registrations.splice(i, 1);
+            break;
+          }
+        }
+      }, this);
+      this.records_ = [];
+    },
+    takeRecords: function() {
+      var copyOfRecords = this.records_;
+      this.records_ = [];
+      return copyOfRecords;
+    }
+  };
+  function MutationRecord(type, target) {
+    this.type = type;
+    this.target = target;
+    this.addedNodes = [];
+    this.removedNodes = [];
+    this.previousSibling = null;
+    this.nextSibling = null;
+    this.attributeName = null;
+    this.attributeNamespace = null;
+    this.oldValue = null;
+  }
+  function copyMutationRecord(original) {
+    var record = new MutationRecord(original.type, original.target);
+    record.addedNodes = original.addedNodes.slice();
+    record.removedNodes = original.removedNodes.slice();
+    record.previousSibling = original.previousSibling;
+    record.nextSibling = original.nextSibling;
+    record.attributeName = original.attributeName;
+    record.attributeNamespace = original.attributeNamespace;
+    record.oldValue = original.oldValue;
+    return record;
+  }
+  var currentRecord, recordWithOldValue;
+  function getRecord(type, target) {
+    return currentRecord = new MutationRecord(type, target);
+  }
+  function getRecordWithOldValue(oldValue) {
+    if (recordWithOldValue) return recordWithOldValue;
+    recordWithOldValue = copyMutationRecord(currentRecord);
+    recordWithOldValue.oldValue = oldValue;
+    return recordWithOldValue;
+  }
+  function clearRecords() {
+    currentRecord = recordWithOldValue = undefined;
+  }
+  function recordRepresentsCurrentMutation(record) {
+    return record === recordWithOldValue || record === currentRecord;
+  }
+  function selectRecord(lastRecord, newRecord) {
+    if (lastRecord === newRecord) return lastRecord;
+    if (recordWithOldValue && recordRepresentsCurrentMutation(lastRecord)) return recordWithOldValue;
+    return null;
+  }
+  function Registration(observer, target, options) {
+    this.observer = observer;
+    this.target = target;
+    this.options = options;
+    this.transientObservedNodes = [];
+  }
+  Registration.prototype = {
+    enqueue: function(record) {
+      var records = this.observer.records_;
+      var length = records.length;
+      if (records.length > 0) {
+        var lastRecord = records[length - 1];
+        var recordToReplaceLast = selectRecord(lastRecord, record);
+        if (recordToReplaceLast) {
+          records[length - 1] = recordToReplaceLast;
+          return;
+        }
+      } else {
+        scheduleCallback(this.observer);
+      }
+      records[length] = record;
+    },
+    addListeners: function() {
+      this.addListeners_(this.target);
+    },
+    addListeners_: function(node) {
+      var options = this.options;
+      if (options.attributes) node.addEventListener("DOMAttrModified", this, true);
+      if (options.characterData) node.addEventListener("DOMCharacterDataModified", this, true);
+      if (options.childList) node.addEventListener("DOMNodeInserted", this, true);
+      if (options.childList || options.subtree) node.addEventListener("DOMNodeRemoved", this, true);
+    },
+    removeListeners: function() {
+      this.removeListeners_(this.target);
+    },
+    removeListeners_: function(node) {
+      var options = this.options;
+      if (options.attributes) node.removeEventListener("DOMAttrModified", this, true);
+      if (options.characterData) node.removeEventListener("DOMCharacterDataModified", this, true);
+      if (options.childList) node.removeEventListener("DOMNodeInserted", this, true);
+      if (options.childList || options.subtree) node.removeEventListener("DOMNodeRemoved", this, true);
+    },
+    addTransientObserver: function(node) {
+      if (node === this.target) return;
+      this.addListeners_(node);
+      this.transientObservedNodes.push(node);
+      var registrations = registrationsTable.get(node);
+      if (!registrations) registrationsTable.set(node, registrations = []);
+      registrations.push(this);
+    },
+    removeTransientObservers: function() {
+      var transientObservedNodes = this.transientObservedNodes;
+      this.transientObservedNodes = [];
+      transientObservedNodes.forEach(function(node) {
+        this.removeListeners_(node);
+        var registrations = registrationsTable.get(node);
+        for (var i = 0; i < registrations.length; i++) {
+          if (registrations[i] === this) {
+            registrations.splice(i, 1);
+            break;
+          }
+        }
+      }, this);
+    },
+    handleEvent: function(e) {
+      e.stopImmediatePropagation();
+      switch (e.type) {
+       case "DOMAttrModified":
+        var name = e.attrName;
+        var namespace = e.relatedNode.namespaceURI;
+        var target = e.target;
+        var record = new getRecord("attributes", target);
+        record.attributeName = name;
+        record.attributeNamespace = namespace;
+        var oldValue = e.attrChange === MutationEvent.ADDITION ? null : e.prevValue;
+        forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+          if (!options.attributes) return;
+          if (options.attributeFilter && options.attributeFilter.length && options.attributeFilter.indexOf(name) === -1 && options.attributeFilter.indexOf(namespace) === -1) {
+            return;
+          }
+          if (options.attributeOldValue) return getRecordWithOldValue(oldValue);
+          return record;
+        });
+        break;
 
-export default MutationObserver;
+       case "DOMCharacterDataModified":
+        var target = e.target;
+        var record = getRecord("characterData", target);
+        var oldValue = e.prevValue;
+        forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+          if (!options.characterData) return;
+          if (options.characterDataOldValue) return getRecordWithOldValue(oldValue);
+          return record;
+        });
+        break;
+
+       case "DOMNodeRemoved":
+        this.addTransientObserver(e.target);
+
+       case "DOMNodeInserted":
+        var changedNode = e.target;
+        var addedNodes, removedNodes;
+        if (e.type === "DOMNodeInserted") {
+          addedNodes = [ changedNode ];
+          removedNodes = [];
+        } else {
+          addedNodes = [];
+          removedNodes = [ changedNode ];
+        }
+        var previousSibling = changedNode.previousSibling;
+        var nextSibling = changedNode.nextSibling;
+        var record = getRecord("childList", e.target.parentNode);
+        record.addedNodes = addedNodes;
+        record.removedNodes = removedNodes;
+        record.previousSibling = previousSibling;
+        record.nextSibling = nextSibling;
+        forEachAncestorAndObserverEnqueueRecord(e.relatedNode, function(options) {
+          if (!options.childList) return;
+          return record;
+        });
+      }
+      clearRecords();
+    }
+  };
+  global.JsMutationObserver = JsMutationObserver;
+  if (!global.MutationObserver) global.MutationObserver = JsMutationObserver;
+})(this);
+})(); // Atlassian: added IIFE

--- a/test/lib/polyfills.js
+++ b/test/lib/polyfills.js
@@ -1,60 +1,6 @@
 (function() {
   'use strict';
 
-  var HTMLElement = window.HTMLElement;
-  var MutationObserver = window.MutationObserver;
-
-
-
-  // Polyfill DOMAttrModified for PhantomJS
-  // --------------------------------------
-
-  if (!MutationObserver) {
-    HTMLElement.prototype.__setAttribute = HTMLElement.prototype.setAttribute;
-    HTMLElement.prototype.setAttribute = function(attrName, newVal)
-    {
-      var prevVal = this.getAttribute(attrName);
-      this.__setAttribute(attrName, newVal);
-      newVal = this.getAttribute(attrName);
-      if (newVal !== prevVal)
-      {
-        var evt = document.createEvent('MutationEvent');
-        evt.initMutationEvent(
-          'DOMAttrModified',
-          true,
-          false,
-          this,
-          prevVal || '',
-          newVal || '',
-          attrName,
-          (prevVal === null) ? evt.ADDITION : evt.MODIFICATION
-        );
-        this.dispatchEvent(evt);
-      }
-    };
-
-    HTMLElement.prototype.__removeAttribute = HTMLElement.prototype.removeAttribute;
-    HTMLElement.prototype.removeAttribute = function(attrName)
-    {
-      var prevVal = this.getAttribute(attrName);
-      this.__removeAttribute(attrName);
-      var evt = document.createEvent('MutationEvent');
-      evt.initMutationEvent(
-        'DOMAttrModified',
-        true,
-        false,
-        this,
-        prevVal,
-        '',
-        attrName,
-        evt.REMOVAL
-      );
-      this.dispatchEvent(evt);
-    };
-  }
-
-
-
   // Function.prototype.bind
   // -----------------------
 

--- a/test/unit/mutation-observer.js
+++ b/test/unit/mutation-observer.js
@@ -1,26 +1,76 @@
 'use strict';
 
 import helpers from '../lib/helpers';
-import MutationObserverPolyfill from '../../src/mutation-observer';
+import '../../src/mutation-observer';
 
 describe('MutationObserver polyfill', function () {
 
     it('should detect a mutation', function(done) {
       let fixture = helpers.fixture();
-
       fixture.setAttribute('checked','');
 
-      let observer = new MutationObserverPolyfill((mutations) => {
-        expect(mutations.length).to.equal(1);
-        expect(mutations[0].type).to.equal('attributes');
-        expect(mutations[0].oldValue).to.be.null;
-        observer.disconnect();
-        done();
-      });
+      helpers.afterMutations(function() {
+        let observer = new window.MutationObserver((mutations) => {
+          expect(mutations.length).to.equal(1);
+          expect(mutations[0].type).to.equal('attributes');
+          expect(mutations[0].oldValue).to.be.null;
+          observer.disconnect();
+          done();
+        });
 
-      observer.observe(fixture, {
-        attributes: true
+        observer.observe(fixture, {
+          attributes: true
+        });
+
+        fixture.removeAttribute('checked');
       });
-      fixture.removeAttribute('checked');
+    });
+
+
+    it('should use old values when removing', function(done) {
+      let fixture = helpers.fixture();
+      fixture.setAttribute('checked','');
+
+      helpers.afterMutations(function() {
+        let observer = new window.MutationObserver((mutations) => {
+          expect(mutations.length).to.equal(1);
+          expect(mutations[0].type).to.equal('attributes');
+          expect(mutations[0].oldValue).to.equal('');
+          expect(typeof mutations[0].newValue).to.equal('undefined');
+          observer.disconnect();
+          done();
+        });
+
+        observer.observe(fixture, {
+          attributes: true,
+          attributeOldValue: true
+        });
+
+        fixture.removeAttribute('checked');
+      });
+    });
+
+    it('should use old values when adding', function(done) {
+      let fixture = helpers.fixture();
+      let attributeName = 'foo';
+      helpers.afterMutations(function() {
+        let observer = new window.MutationObserver((mutations) => {
+          expect(mutations.length).to.equal(1);
+          expect(mutations[0].attributeName).to.equal(attributeName);
+          expect(mutations[0].type).to.equal('attributes');
+          expect(mutations[0].oldValue).to.equal(null);
+          expect(typeof mutations[0].newValue).to.equal('undefined');
+          observer.disconnect();
+          done();
+        });
+
+        observer.observe(fixture, {
+          attributes: true,
+          attributeOldValue: true
+        });
+      });
+      helpers.afterMutations(function() {
+        fixture.setAttribute(attributeName,'bla');
+      });
     });
 });


### PR DESCRIPTION
This fixes the lifecycle management on IE (e.g. incorrect calls to `fallback` instead of `created` and `removed`).