### PR TITLE
chore: fix singleRun

### DIFF
--- a/build/task/test.js
+++ b/build/task/test.js
@@ -28,7 +28,7 @@ module.exports = function (opts, done) {
     browsers: opts.browsers.split(','),
     client: { args: args },
     frameworks: ['mocha', 'sinon-chai'],
-    singleRun: true,
+    singleRun: !opts.watch,
     files: [
       '.tmp/unit.js'
     ]


### PR DESCRIPTION
Broke watching when backporting saucelabs from master