### PR TITLE
chore: use webcomponents.js MutationObserver polyfill

### DIFF
--- a/build/task/build-test.js
+++ b/build/task/build-test.js
@@ -2,11 +2,16 @@ var galv = require('galvatron');
 var gulp = require('gulp');
 var gulpBabel = require('gulp-babel');
 var gulpConcat = require('gulp-concat');
+var gulpFilter = require('gulp-filter');
 
 module.exports = function () {
+  var filterEverythingExceptWebcomponents = gulpFilter(['**/*','!**/webcomponents.js/**/*'], { restore: true });
+
   return gulp.src('test/unit.js')
     .pipe(galv.trace())
+    .pipe(filterEverythingExceptWebcomponents)
     .pipe(galv.cache('babel', gulpBabel()))
+    .pipe(filterEverythingExceptWebcomponents.restore)
     .pipe(galv.cache('globalize', galv.globalize()))
     .pipe(gulpConcat('unit.js'))
     .pipe(gulp.dest('.tmp'));

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "merge-stream": "1.0.0",
     "mocha": "2.3.3",
     "shadejs": "skatejs/shade#2a69707",
-    "skatejs-polyfill-mutation-observer": "skatejs/polyfill-mutation-observer#a7dbecf",
     "skatejs-type-attribute": "skatejs/type-attribute#28140f7",
     "skatejs-type-class": "skatejs/type-class#8302a2f",
+    "webcomponents.js": "0.7.2",
     "whatwg-fetch": "0.10.0"
   },
   "scripts": {

--- a/test/boot.js
+++ b/test/boot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import 'skatejs-polyfill-mutation-observer';
+import 'webcomponents.js/MutationObserver';
 import helperFixture from './lib/fixture';
 import observer from '../src/global/document-observer';
 


### PR DESCRIPTION
This adds the webcomponents.js MutationObserver polyfill to skate in order to get some tests for older browsers green.