### PR TITLE
chore(test): add Opera for saucelabs

### DIFF
--- a/build/lib/saucelabs-launchers.js
+++ b/build/lib/saucelabs-launchers.js
@@ -73,5 +73,10 @@ module.exports = {
     browserName: 'microsoftedge',
     version: '20.10240',
     platform: 'Windows 10'
+  },
+  opera_12: {
+    base: 'SauceLabs',
+    browserName: 'opera',
+    version: '12'
   }
 };


### PR DESCRIPTION
This adds Opera as a browser for our saucelabs tests