### PR TITLE
chore(test): add Safari 8 to saucelabs-tested browsers

### DIFF
--- a/build/lib/saucelabs-launchers.js
+++ b/build/lib/saucelabs-launchers.js
@@ -50,6 +50,12 @@ module.exports = {
     browserName: 'safari',
     platform: 'OS X 10.11'
   },
+  safari_8_osx: {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    version: '8.0',
+    platform: 'OS X 10.10'
+  },
   ie_9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',


### PR DESCRIPTION
This adds Safari 8 to the list of our saucelabs-tested browsers