### PR TITLE
fix(IE innerHTML): only enhance once

### DIFF
--- a/src/fix/ie/innerhtml.js
+++ b/src/fix/ie/innerhtml.js
@@ -2,7 +2,7 @@ const isIeUntil10 = /MSIE/.test(navigator.userAgent);
 const isIe11 = /Trident/.test(navigator.userAgent);
 const elementPrototype = window.HTMLElement.prototype;
 const propertyDescriptor = Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
-let hasBeenEnhanced = !!propertyDescriptor && propertyDescriptor.get._hasBeenEnhanced;
+const hasBeenEnhanced = !!propertyDescriptor && propertyDescriptor.get._hasBeenEnhanced;
 
 // ! This walkTree method differs from the implementation in ../../utils/walk-tree
 // It invokes the callback only for the children, not the passed node and the second parameter to the callback is the parent node

--- a/src/fix/ie/innerhtml.js
+++ b/src/fix/ie/innerhtml.js
@@ -1,7 +1,7 @@
 const isIeUntil10 = /MSIE/.test(navigator.userAgent);
 const isIe11 = /Trident/.test(navigator.userAgent);
 const elementPrototype = window.HTMLElement.prototype;
-let fixed = !!Object.getOwnPropertyDescriptor(elementPrototype,'innerHTML');
+let fixed = !!Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
 
 // ! This walkTree method differs from the implementation in ../../utils/walk-tree
 // It invokes the callback only for the children, not the passed node and the second parameter to the callback is the parent node

--- a/src/fix/ie/innerhtml.js
+++ b/src/fix/ie/innerhtml.js
@@ -1,6 +1,7 @@
 const isIeUntil10 = /MSIE/.test(navigator.userAgent);
 const isIe11 = /Trident/.test(navigator.userAgent);
-let fixed = false;
+const elementPrototype = window.HTMLElement.prototype;
+let fixed = !!Object.getOwnPropertyDescriptor(elementPrototype,'innerHTML');
 
 // ! This walkTree method differs from the implementation in ../../utils/walk-tree
 // It invokes the callback only for the children, not the passed node and the second parameter to the callback is the parent node
@@ -21,7 +22,6 @@ function walkTree (node, cb) {
 }
 
 function fixInnerHTML() {
-  const elementPrototype = window.HTMLElement.prototype;
   const originalInnerHTML = Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
 
   // This redefines the innerHTML property so that we can ensure that events
@@ -43,7 +43,6 @@ function fixInnerHTML() {
 
 if (!fixed && (isIeUntil10 || isIe11)) {
   // IE 9-11
-  fixed = true; // make sure we add the enhancement only once
 
   if (isIe11) {
     // IE11's native MutationObserver needs some help as well :()

--- a/src/fix/ie/innerhtml.js
+++ b/src/fix/ie/innerhtml.js
@@ -1,8 +1,7 @@
 const isIeUntil10 = /MSIE/.test(navigator.userAgent);
 const isIe11 = /Trident/.test(navigator.userAgent);
+const isIe = isIeUntil10 || isIe11;
 const elementPrototype = window.HTMLElement.prototype;
-const propertyDescriptor = Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
-const hasBeenEnhanced = !!propertyDescriptor && propertyDescriptor.get._hasBeenEnhanced;
 
 // ! This walkTree method differs from the implementation in ../../utils/walk-tree
 // It invokes the callback only for the children, not the passed node and the second parameter to the callback is the parent node
@@ -45,13 +44,17 @@ function fixInnerHTML() {
   });
 }
 
-if (!hasBeenEnhanced && (isIeUntil10 || isIe11)) {
+if (isIe) {
   // IE 9-11
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(elementPrototype, 'innerHTML');
+  const hasBeenEnhanced = !!propertyDescriptor && propertyDescriptor.get._hasBeenEnhanced;
 
-  if (isIe11) {
-    // IE11's native MutationObserver needs some help as well :()
-    window.MutationObserver = window.JsMutationObserver || window.MutationObserver;
+  if (!hasBeenEnhanced) {
+    if (isIe11) {
+      // IE11's native MutationObserver needs some help as well :()
+      window.MutationObserver = window.JsMutationObserver || window.MutationObserver;
+    }
+
+    fixInnerHTML();
   }
-
-  fixInnerHTML();
 }


### PR DESCRIPTION
This fix makes sure that the `innerHTML` fixes regarding `DOMNodeRemoved` delegation only get applied once. This is important if we run multiple skate versions on one page.