### PR TITLE
Add stricter checks for element names

### DIFF
--- a/src/support/valid-custom-element.js
+++ b/src/support/valid-custom-element.js
@@ -10,5 +10,5 @@ export default function (name) {
     'missing-glyph'
   ];
 
-  return name.indexOf('-') > 0 && name.toUpperCase() === name && reservedNames.indexOf(name) < 0;
+  return name.indexOf('-') > 0 && name.toLowerCase() === name && reservedNames.indexOf(name) < 0;
 }

--- a/src/support/valid-custom-element.js
+++ b/src/support/valid-custom-element.js
@@ -1,3 +1,14 @@
 export default function (name) {
-  return name.indexOf('-') > 0;
+  const reservedNames = [
+    'annotation-xml',
+    'color-profile',
+    'font-face',
+    'font-face-src',
+    'font-face-uri',
+    'font-face-format',
+    'font-face-name',
+    'missing-glyph'
+  ];
+
+  return name.indexOf('-') > 0 && name.toUpperCase() === name && !reservedNames.includes(name);
 }

--- a/src/support/valid-custom-element.js
+++ b/src/support/valid-custom-element.js
@@ -10,5 +10,5 @@ export default function (name) {
     'missing-glyph'
   ];
 
-  return name.indexOf('-') > 0 && name.toUpperCase() === name && !reservedNames.includes(name);
+  return name.indexOf('-') > 0 && name.toUpperCase() === name && reservedNames.indexOf(name) < 0;
 }


### PR DESCRIPTION
Implements http://www.w3.org/TR/custom-elements/#dfn-custom-element-type, namely:
- all characters must be lowercase
- name must not be one of
 - 'annotation-xml',
 - 'color-profile',
 - 'font-face',
 - 'font-face-src',
 - 'font-face-uri',
 - 'font-face-format',
 - 'font-face-name',
 - 'missing-glyph'