### PR TITLE
#433 - Use property functions instead of objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "author": "Trey Shugart <treshugart@gmail.com> (http://treshugart.github.io)",
   "repository": "git@github.com:skatejs/skatejs",
   "main": "lib/index.js",
-  "dependencies": {},
+  "dependencies": {
+    "object-assign": "^4.0.1"
+  },
   "devDependencies": {
     "bootstrap": "3.3.5",
     "eslint": "1.8.0",
     "font-awesome": "4.4.0",
     "highlight.js": "8.9.1",
-    "object-assign": "^4.0.1",
     "shadejs": "skatejs/shade#2a69707",
     "skatejs-build": "skatejs/build#184a544",
     "skatejs-types": "skatejs/types#1e9725b",

--- a/src/api/properties/boolean.js
+++ b/src/api/properties/boolean.js
@@ -1,6 +1,7 @@
-export default {
+import assign from 'object-assign';
+export default assign.bind(null, {}, {
   coerce: value => !!value,
   default: false,
   deserialize: value => !(value === null),
   serialize: value => value ? '' : undefined
-};
+});

--- a/src/api/properties/float.js
+++ b/src/api/properties/float.js
@@ -1,6 +1,7 @@
-export default {
+import assign from 'object-assign';
+export default assign.bind(null, {}, {
   coerce: parseFloat,
   default: 0,
   serialize: String,
   deserialize: parseFloat
-};
+});

--- a/src/api/properties/float.js
+++ b/src/api/properties/float.js
@@ -1,7 +1,0 @@
-import assign from 'object-assign';
-export default assign.bind(null, {}, {
-  coerce: parseFloat,
-  default: 0,
-  serialize: String,
-  deserialize: parseFloat
-});

--- a/src/api/properties/index.js
+++ b/src/api/properties/index.js
@@ -1,11 +1,9 @@
 import boolean from './boolean';
-import float from './float';
 import number from './number';
 import string from './string';
 
 export default {
   boolean,
-  float,
   number,
   string
 };

--- a/src/api/properties/number.js
+++ b/src/api/properties/number.js
@@ -1,6 +1,7 @@
-export default {
+import assign from 'object-assign';
+export default assign.bind(null, {}, {
   type: Number,
   default: 0,
   serialize: String,
   deserialize: Number
-};
+});

--- a/src/api/properties/number.js
+++ b/src/api/properties/number.js
@@ -1,7 +1,6 @@
 import assign from 'object-assign';
 export default assign.bind(null, {}, {
-  type: Number,
-  default: 0,
-  serialize: String,
-  deserialize: Number
+  coerce: value => typeof value === 'undefined' ? value : Number(value),
+  deserialize: value => value === null ? undefined : value,
+  serialize: value => typeof value === 'undefined' ? value : Number(value)
 });

--- a/src/api/properties/string.js
+++ b/src/api/properties/string.js
@@ -1,7 +1,6 @@
 import assign from 'object-assign';
 export default assign.bind(null, {}, {
-  type: String,
-  default: '',
-  deserialize: String,
-  serialize: String
+  coerce: value => typeof value === 'undefined' ? value : String(value),
+  deserialize: value => value === null ? undefined : value,
+  serialize: value => typeof value === 'undefined' ? value : String(value)
 });

--- a/src/api/properties/string.js
+++ b/src/api/properties/string.js
@@ -1,6 +1,7 @@
-export default {
+import assign from 'object-assign';
+export default assign.bind(null, {}, {
   type: String,
   default: '',
   deserialize: String,
   serialize: String
-};
+});

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -10,10 +10,10 @@ function create (prop) {
   })();
 }
 
-describe('api/property', function () {
+describe('api/properties', function () {
   describe('boolean', function () {
     it('initial value', function () {
-      let elem = create(properties.boolean);
+      let elem = create(properties.boolean());
       expect(elem.test).to.equal(false);
       expect(elem.getAttribute('test')).to.equal(null);
     });
@@ -21,13 +21,13 @@ describe('api/property', function () {
     [undefined, null, false, 0, '', 'something'].forEach(function (value) {
       value = JSON.stringify(value);
       it('setting attribute to ' + value, function () {
-        let elem = create(properties.boolean);
+        let elem = create(properties.boolean());
         elem.setAttribute('test', value);
         expect(elem.test).to.equal(true, 'property');
         expect(elem.getAttribute('test')).to.equal(String(value), 'attribute');
       });
       it('setting property to ' + value, function () {
-        let elem = create(properties.boolean);
+        let elem = create(properties.boolean());
         elem.test = value;
         expect(elem.test).to.equal(!!value, 'property');
         expect(elem.getAttribute('test')).to.equal(value ? '' : null, 'attribute');
@@ -35,7 +35,7 @@ describe('api/property', function () {
     });
 
     it('removing attribute', function () {
-      let elem = create(properties.boolean);
+      let elem = create(properties.boolean());
       elem.setAttribute('test', '');
       expect(elem.test).to.equal(true);
       elem.removeAttribute('test');
@@ -45,7 +45,7 @@ describe('api/property', function () {
 
   describe('float', function () {
     it('default', function () {
-      let elem = create(properties.float);
+      let elem = create(properties.float());
       expect(elem.test).to.equal(0);
       expect(elem.getAttribute('test')).to.equal('0');
     });
@@ -53,7 +53,7 @@ describe('api/property', function () {
 
   describe('number', function () {
     it('default', function () {
-      let elem = create(properties.number);
+      let elem = create(properties.number());
       expect(elem.test).to.equal(0);
       expect(elem.getAttribute('test')).to.equal('0');
     });
@@ -61,7 +61,7 @@ describe('api/property', function () {
 
   describe('string', function () {
     it('default', function () {
-      let elem = create(properties.string);
+      let elem = create(properties.string());
       expect(elem.test).to.equal('');
       expect(elem.getAttribute('test')).to.equal('');
     });

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -10,6 +10,15 @@ function create (prop) {
   })();
 }
 
+function testTypeValues (type, values) {
+  const elem = create(properties[type]());
+  values.forEach(function (value) {
+    elem.test = value[0];
+    expect(elem.test).to.equal(value[1], 'property');
+    expect(elem.getAttribute('test')).to.equal(value[2], 'attribute');
+  });
+}
+
 describe('api/properties', function () {
   describe('boolean', function () {
     it('initial value', function () {
@@ -43,27 +52,47 @@ describe('api/properties', function () {
     });
   });
 
-  describe('float', function () {
-    it('default', function () {
-      let elem = create(properties.float());
-      expect(elem.test).to.equal(0);
-      expect(elem.getAttribute('test')).to.equal('0');
-    });
-  });
-
   describe('number', function () {
     it('default', function () {
       let elem = create(properties.number());
-      expect(elem.test).to.equal(0);
-      expect(elem.getAttribute('test')).to.equal('0');
+      expect(elem.test).to.equal(undefined);
+      expect(elem.getAttribute('test')).to.equal(null);
+      testTypeValues('number', [
+        [false, 0, '0'],
+        [null, 0, '0'],
+        [undefined, undefined, null],
+        [0.1, 0.1, '0.1'],
+        ['', 0, '0']
+      ]);
     });
   });
 
   describe('string', function () {
-    it('default', function () {
+    it('values', function () {
       let elem = create(properties.string());
-      expect(elem.test).to.equal('');
-      expect(elem.getAttribute('test')).to.equal('');
+      expect(elem.test).to.equal(undefined);
+      expect(elem.getAttribute('test')).to.equal(null);
+      testTypeValues('string', [
+        [false, 'false', 'false'],
+        [null, 'null', 'null'],
+        [undefined, undefined, null],
+        [0, '0', '0'],
+        ['', '', '']
+      ]);
+    });
+  });
+
+  describe('overriding', function () {
+    it('boolean', function () {
+      expect(properties.boolean({ default: true }).default).to.equal(true);
+    });
+
+    it('number', function () {
+      expect(properties.number({ default: 1 }).default).to.equal(1);
+    });
+
+    it('string', function () {
+      expect(properties.string({ default: 'test' }).default).to.equal('test');
     });
   });
 });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -23,7 +23,6 @@ describe('exports', function () {
 
   it('skate.properties', function () {
     expect(skate.properties.boolean).to.be.a('function', 'boolean');
-    expect(skate.properties.float).to.be.a('function', 'float');
     expect(skate.properties.number).to.be.a('function', 'number');
     expect(skate.properties.string).to.be.a('function', 'string');
   });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -22,10 +22,10 @@ describe('exports', function () {
   });
 
   it('skate.properties', function () {
-    expect(skate.properties.boolean).to.be.an('object', 'boolean');
-    expect(skate.properties.float).to.be.an('object', 'float');
-    expect(skate.properties.number).to.be.an('object', 'number');
-    expect(skate.properties.string).to.be.an('object', 'string');
+    expect(skate.properties.boolean).to.be.a('function', 'boolean');
+    expect(skate.properties.float).to.be.a('function', 'float');
+    expect(skate.properties.number).to.be.a('function', 'number');
+    expect(skate.properties.string).to.be.a('function', 'string');
   });
 
   it('skate.ready', function () {


### PR DESCRIPTION
Also allows typed properties to have an `undefined` value.