### PR TITLE
#441 - Throw an error if MutationObserver is not defined if required …

### DIFF
--- a/src/global/document-observer.js
+++ b/src/global/document-observer.js
@@ -51,8 +51,16 @@ function documentObserverHandler (mutations) {
   }
 }
 
+function createMutationObserver () {
+  const { MutationObserver} = window;
+  if (!MutationObserver) {
+    throw new Error('Mutation Observers are not supported by this browser. Skate requires them in order to polyfill the behaviour of Custom Elements. If you want to support this browser you should include a Mutation Observer polyfill before Skate.');
+  }
+  return new MutationObserver(documentObserverHandler);
+}
+
 function createDocumentObserver () {
-  var observer = new window.MutationObserver(documentObserverHandler);
+  var observer = createMutationObserver();
   observer.observe(document, {
     childList: true,
     subtree: true

--- a/test/unit/document-observer.js
+++ b/test/unit/document-observer.js
@@ -43,4 +43,11 @@ describe('Document Observer', function () {
     observer.register();
     expect(getObserver()).to.equal(oldObserver);
   });
+
+  it('should throw an error if a MutationObserver implementation isn\'t found', function () {
+    const oldMutationObserver = window.MutationObserver;
+    window.MutationObserver = undefined;
+    expect(observer.register).to.throw('Mutation Observers are not supported by this browser. Skate requires them in order to polyfill the behaviour of Custom Elements. If you want to support this browser you should include a Mutation Observer polyfill before Skate.');
+    window.MutationObserver = oldMutationObserver;
+  });
 });


### PR DESCRIPTION
…in the document observer.