### PR TITLE
Missing default of `render` 

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -11,6 +11,10 @@ export default {
   // called on them.
   created: function () {},
 
+  // Responsible for rendering stuff to the host element. This can do anything
+  // you like.
+  render: function () {},
+
   // Called when the element is detached from the document.
   detached: function () {},
 


### PR DESCRIPTION
My first code-contribution to skate.

The missing default is actually preventing copying over `render` from user options when they are passed as ES6 class.

Another thing I noticed is that options are treated as enumerable but they can also be a class which is not enumerable. I only fixed the defaults here. Issue should be opened for the enumerable problem.