### PR TITLE
Document the 'detail' option for skate.emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,17 @@ skate.emit(element, 'event', {
 });
 ```
 
+#### Passing Data
+
+You can pass data when initializing the event with the `detail` option in the `eventOptions` argument.
+
+```js
+skate.emit(element, 'event', {
+  detail: {
+    data: 'my-data'
+  }
+});
+```
 
 
 ### `fragment (...almostAnything)`


### PR DESCRIPTION
Add a short section to document the `detail` option for `eventOptions` in `skate.emit`