### PR TITLE
#475 - only one element may be upgraded with a single component's behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Result
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Compatibility](#compatibility)
 - [Installing](#installing)
   - [UMD (AMD / CommonJS)](#umd-amd--commonjs)
   - [ES6 Modules](#es6-modules)
@@ -130,27 +129,15 @@ Result
 
 
 
-## Compatibility
-
-See the Sauce Labs badge at the top.
-
-
-
 ## Installing
 
-You can download the source yourself and put it wherever you want. Additionally you can use Bower:
+Using package managers:
 
     bower install skatejs
-
-Or NPM:
-
+    jspm install npm:skatejs
     npm install skatejs
 
-Or JSPM:
-
-    jspm install npm:skatejs
-
-Include either `dist/skate.js` or `dist/skate.min.js`.
+Or you can DIY by downloading the zip and consuming it via one of the following ways.
 
 
 
@@ -162,13 +149,13 @@ UMD files are located in `lib/`. Simply `require` the `lib/index.js` file by wha
 
 ### ES6 Modules
 
-The Skate source is written using [ES6 modules](http://www.2ality.com/2014/09/es6-modules-final.html). If you're using a transpilation method, then you can `import skate from 'src/index';` and use it in your projects as you would any ES6 module.
+The Skate source is written using [ES2015 modules](http://www.2ality.com/2014/09/es6-modules-final.html). If you're using a transpilation method, then you can `import skate from 'src/index';` and use it in your projects as you would any ES6 module.
 
 
 
 ### Global
 
-If you're still skating old school the `dist` directory contains the compiled ES5 source. The compiled source does not use a module loader; everything will just work. Access Skate as a global with `skate`.
+If you're still skating old school the `dist` directory contains the bundled ES5 source and contains both a UMD definition and a global `skate` variable.
 
 
 
@@ -186,6 +173,7 @@ If you're still skating old school the `dist` directory contains the compiled ES
 - [Web Platform Podcast: Custom Elements & SkateJS (#66)](https://www.youtube.com/watch?v=AbolmN4mp-g)
 - [SydJS: Skating with Web Components](http://slides.com/treshugart/skating-with-web-components#/)
 - [SydJS: Still got your Skate on](http://slides.com/treshugart/still-got-your-skate-on#/)
+- [Kickflip: Functional web components with SkateJS](https://github.com/skatejs/kickflip)
 
 
 
@@ -280,7 +268,7 @@ document.registerElement('my-component', {
 });
 ```
 
-With Skate, if your `prototype` doesn't inherit from the base `HTMLElement`, it will automatically do this for you.
+If your `prototype` doesn't inherit from the base `HTMLElement`, Skate will automatically do this for you.
 
 
 
@@ -599,7 +587,7 @@ skate('my-component', {
 });
 ```
 
-The only argument passed to `render` is component element. In this case that is `<my-component>`.
+The only argument passed to `render` is the component element. In this case that is `<my-component>`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -742,12 +742,13 @@ Skate supports custom bindings such as the ability to bind functionality to elem
 The actual binding functionality isn't built into Skate. Skate simply offers an API for you to use custom bindings that you or others have written. If you want to write a binding, all you have to do is provide a particular interface for Skate to call.
 
 ```js
-var myCustomBidning = {
+var myCustomBinding = {
   create: function (componentDefinition) {
     // Create an element matching the component definition.
   },
-  filter: function (element, componentDefinitions) {
-    // Return an array of definitions that the element should initialise with.
+  reduce: function (element, componentDefinitions) {
+    // Return the component that the element should upgrade to, or falsy if it
+    // doesn't exist.
   }
 };
 ```
@@ -761,7 +762,7 @@ There's some that we've already built for you over at https://github.com/skatejs
 There's a few things that you must consider when building and using custom bindings:
 
 - You're deviating from the spec - Skate will always be a superset of the custom element spec. This means that core-Skate will never stray too far from the spec other than offering a more convenient API and featureset.
-- Performance - The `filter` callback is performance-critical. This function *must* be run for every single element that comes into existence. Be very aware of this.
+- Performance - The `reduce` callback is performance-critical. This function *must* be run for every single element that comes into existence. Be very aware of this.
 - With great power comes great responsibility - No matter if we decided to expose this as API or not, we'd still have to do a similar algorithm behind the scenes. Since there are many use-cases where writing a component with the Skate API is useful, we felt it was best to offer safe, spec-backed defaults while giving developers a little bit of breathing room.
 
 
@@ -783,10 +784,10 @@ With Skate, those problems vanish. No selectors are run and your tabs will autom
 To refactor that into a Skate component, all you need to do is:
 
 ```js
-var typeClass = require('skatejs-type-class');
+var types = require('skatejs-types');
 
 skate('tabs', {
-  type: typeClass,
+  type: types.classname,
   created: function (element) {
     jQuery(element).tabs();
   }

--- a/README.md
+++ b/README.md
@@ -1346,6 +1346,32 @@ If your component is not using custom types and your browser supports custom ele
 
 
 
+## SVG
+
+When using custom elements in SVG, you need to explicitly extend the `SVGElement.prototype` as well as set the `extends` option to a valid `SVGElement` name:
+
+```js
+skate('my-path', {
+  extends: 'path',
+  prototype: Object.create(SVGElement.prototype)
+});
+```
+
+Then you may write the following:
+
+```js
+<svg xmlns="http://www.w3.org/2000/svg">
+  <circle />
+  <path is="my-path" />
+</svg>
+```
+
+The [custom element spec](http://w3c.github.io/webcomponents/spec/custom/#registering-custom-elements) is very vague on SVG and it would seem that it implies you don't need to specify `extends`. However, this is not the case in Chrome under native support it would seem. This is not an implementation detail of Skate, but the spec and the browser implementations.
+
+Theoretically, Skate could automatically detect this and extend `path` by default (as it is the most generic SVG element), but then it would be ambiguous when reading your custom element definition as to what - and if - it is extending. For that reason, we leave this up to you.
+
+
+
 ## Polyfills
 
 As you may know, the only way to polyfill Mutation Observers is to use the deprecated DOM 3 Mutation Events. They were deprecated because if you insert 5k elements at once, you then trigger 5k handlers at once. Mutation Observers will batch that into a single callback.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint": "1.10.3",
     "gulp": "gulpjs/gulp#73eced0",
     "skatejs-build": "skatejs/build#4031975",
-    "skatejs-types": "skatejs/types#1e9725b",
     "webcomponents.js": "0.7.20"
   },
   "scripts": {

--- a/src/api/create.js
+++ b/src/api/create.js
@@ -5,6 +5,6 @@ import registry from '../shared/registry';
 export default function (name, props) {
   const Ctor = registry.get(name);
   const elem = Ctor ? Ctor.type.create(Ctor) : document.createElement(name);
-  Ctor && Ctor.isNative || init(elem);
+  Ctor && init(elem);
   return assign(elem, props);
 }

--- a/src/api/init.js
+++ b/src/api/init.js
@@ -7,7 +7,7 @@ export default function (...args) {
     const isInDom = elementContains(document, arg);
     walkTree(arg, function (descendant) {
       const component = registry.find(descendant);
-      if (component) {
+      if (component && !component.isNative) {
         component.prototype.createdCallback.call(descendant);
         isInDom && component.prototype.attachedCallback.call(descendant);
       }

--- a/src/api/init.js
+++ b/src/api/init.js
@@ -6,17 +6,10 @@ export default function (...args) {
   args.forEach(function (arg) {
     const isInDom = elementContains(document, arg);
     walkTree(arg, function (descendant) {
-      const components = registry.find(descendant);
-      const componentsLength = components.length;
-
-      for (let a = 0; a < componentsLength; a++) {
-        components[a].prototype.createdCallback.call(descendant);
-      }
-
-      for (let a = 0; a < componentsLength; a++) {
-        if (isInDom) {
-          components[a].prototype.attachedCallback.call(descendant);
-        }
+      const component = registry.find(descendant);
+      if (component) {
+        component.prototype.createdCallback.call(descendant);
+        isInDom && component.prototype.attachedCallback.call(descendant);
       }
     });
   });

--- a/src/api/ready.js
+++ b/src/api/ready.js
@@ -2,14 +2,8 @@ import data from '../util/data';
 import registry from '../shared/registry';
 
 function ready (element) {
-  const components = registry.find(element);
-  const componentsLength = components.length;
-  for (let a = 0; a < componentsLength; a++) {
-    if (!data(element, `lifecycle/${components[a].id}`).created) {
-      return false;
-    }
-  }
-  return true;
+  const component = registry.find(element);
+  return !component || data(element, `lifecycle/${component.id}`).created;
 }
 
 export default function (elements, callback) {

--- a/src/api/render.js
+++ b/src/api/render.js
@@ -1,5 +1,8 @@
 import registry from '../shared/registry';
 
 export default function (elem) {
-  registry.find(elem).forEach(component => component.render && component.render(elem));
+  const component = registry.find(elem);
+  if (component && component.render) {
+    component.render(elem);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,11 +78,12 @@ function makeCtor (name, opts) {
 // The main skate() function.
 function skate (name, opts) {
   const Ctor = makeCtor(name, opts);
-  const proto = (Ctor.extends ? document.createElement(Ctor.extends).constructor : HTMLElement).prototype;
 
   // If the options don't inherit a native element prototype, we ensure it does
-  // because native unnecessarily requires you explicitly do this.
-  if (!proto.isPrototypeOf(Ctor.prototype)) {
+  // because native requires you explicitly do this. Here we solve the common
+  // use case by defaulting to HTMLElement.prototype.
+  if (!HTMLElement.prototype.isPrototypeOf(Ctor.prototype) && !SVGElement.prototype.isPrototypeOf(Ctor.prototype)) {
+    const proto = (Ctor.extends ? document.createElement(Ctor.extends).constructor : HTMLElement).prototype;
     Ctor.prototype = Object.create(proto, utilGetOwnPropertyDescriptors(Ctor.prototype));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,23 +25,11 @@ const HTMLElement = window.HTMLElement;
 
 // A function that initialises the document once in a given event loop.
 const initDocument = utilDebounce(function () {
-  // For performance in older browsers, we use:
-  //
-  // - childNodes instead of children
-  // - for instead of forEach
   utilWalkTree(document.documentElement.childNodes, function (element) {
-    const components = registry.find(element);
-    const componentsLength = components.length;
-
-    // Created callbacks are called first.
-    for (let a = 0; a < componentsLength; a++) {
-      components[a].prototype.createdCallback.call(element);
-    }
-
-    // Attached callbacks are called separately because this emulates how
-    // native works internally.
-    for (let a = 0; a < componentsLength; a++) {
-      components[a].prototype.attachedCallback.call(element);
+    const component = registry.find(element);
+    if (component) {
+      component.prototype.createdCallback.call(element);
+      component.prototype.attachedCallback.call(element);
     }
   });
 });

--- a/src/shared/document-observer.js
+++ b/src/shared/document-observer.js
@@ -6,36 +6,28 @@ import walkTree from '../util/walk-tree';
 
 function triggerAddedNodes (addedNodes) {
   walkTree(addedNodes, function (element) {
-    var components = registry.find(element);
-    var componentsLength = components.length;
-
-    for (let a = 0; a < componentsLength; a++) {
-      components[a].prototype.createdCallback.call(element);
-    }
-
-    for (let a = 0; a < componentsLength; a++) {
-      components[a].prototype.attachedCallback.call(element);
+    const component = registry.find(element);
+    if (component) {
+      component.prototype.createdCallback.call(element);
+      component.prototype.attachedCallback.call(element);
     }
   });
 }
 
 function triggerRemovedNodes (removedNodes) {
   walkTree(removedNodes, function (element) {
-    var components = registry.find(element);
-    var componentsLength = components.length;
-
-    for (let a = 0; a < componentsLength; a++) {
-      components[a].prototype.detachedCallback.call(element);
+    const component = registry.find(element);
+    if (component) {
+      component.prototype.detachedCallback.call(element);
     }
   });
 }
 
 function documentObserverHandler (mutations) {
-  var mutationsLength = mutations.length;
-
+  const mutationsLength = mutations.length;
   for (let a = 0; a < mutationsLength; a++) {
-    var addedNodes = mutations[a].addedNodes;
-    var removedNodes = mutations[a].removedNodes;
+    const addedNodes = mutations[a].addedNodes;
+    const removedNodes = mutations[a].removedNodes;
 
     // Since siblings are batched together, we check the first node's parent
     // node to see if it is ignored. If it is then we don't process any added
@@ -60,7 +52,7 @@ function createMutationObserver () {
 }
 
 function createDocumentObserver () {
-  var observer = createMutationObserver();
+  const observer = createMutationObserver();
   observer.observe(document, {
     childList: true,
     subtree: true

--- a/src/shared/registry.js
+++ b/src/shared/registry.js
@@ -3,10 +3,11 @@ import globals from './vars';
 const definitions = {};
 const map = [];
 const types = [];
+const hasOwn = Object.prototype.hasOwnProperty;
 
 export default globals.registerIfNotExists('registry', {
   get (name) {
-    return Object.prototype.hasOwnProperty.call(definitions, name) && definitions[name];
+    return hasOwn.call(definitions, name) && definitions[name];
   },
   set (name, Ctor) {
     if (this.get(name)) {
@@ -25,11 +26,12 @@ export default globals.registerIfNotExists('registry', {
     return definitions[name] = map[typeIndex][name] = Ctor;
   },
   find (elem) {
-    let filtered = [];
     const typesLength = types.length;
     for (let a = 0; a < typesLength; a++) {
-      filtered = filtered.concat(types[a].filter(elem, map[a]) || []);
+      const reduced = types[a].reduce(elem, map[a]);
+      if (reduced) {
+        return reduced;
+      }
     }
-    return filtered;
   }
 });

--- a/src/type/element.js
+++ b/src/type/element.js
@@ -23,24 +23,18 @@ export default {
     }
     return elem;
   },
-  filter (elem, defs) {
-    const attrs = elem.attributes;
-    const isAttr = attrs.is;
-    const isAttrValue = isAttr && (isAttr.value || isAttr.nodeValue);
-    const tagName = (elem.tagName || elem.localName).toLowerCase();
-    const definition = defs[isAttrValue || tagName];
-
-    if (!definition) {
-      return;
+  reduce (elem, defs) {
+    const tagName = elem.tagName;
+    const tagNameLc = tagName && tagName.toLowerCase();
+    if (tagNameLc in defs) {
+      return defs[tagNameLc];
     }
 
-    const tagToExtend = definition.extends;
-    if (isAttrValue) {
-      if (tagName === tagToExtend) {
-        return [definition];
-      }
-    } else if (!tagToExtend) {
-      return [definition];
+    const attributes = elem.attributes;
+    const isAttributeNode = attributes && attributes.is;
+    const isAttributeValue = isAttributeNode && isAttributeNode .value;
+    if (isAttributeValue in defs) {
+      return defs[isAttributeValue];
     }
   },
   register (Ctor) {

--- a/test/unit/api/fragment.js
+++ b/test/unit/api/fragment.js
@@ -1,7 +1,6 @@
 import element from '../../lib/element';
 import resolved from '../../lib/resolved';
 import skate from '../../../src/index';
-import { attribute as typeAttribute } from 'skatejs-types';
 
 describe('api/fragment', function () {
   var tagName;
@@ -42,9 +41,9 @@ describe('api/fragment', function () {
     it('should init an element and its descendents', function () {
       var descendantTagName = element().safe;
       skate(tagName, {});
-      skate(descendantTagName, { type: typeAttribute });
+      skate(descendantTagName, {});
 
-      var html = `<${tagName}><div ${descendantTagName}></div></${tagName}>`;
+      var html = `<${tagName}><${descendantTagName}></${descendantTagName}></${tagName}>`;
       var frag = skate.fragment(html);
       expect(resolved(frag.childNodes[0])).to.equal(true, 'host');
       expect(resolved(frag.childNodes[0].firstElementChild)).to.equal(true, 'descendent');

--- a/test/unit/api/init.js
+++ b/test/unit/api/init.js
@@ -1,9 +1,6 @@
 import helperElement from '../../lib/element';
 import helperFixture from '../../lib/fixture';
 import skate from '../../../src/index';
-import { attribute as typeAttribute } from 'skatejs-types';
-import { classname as typeClass } from 'skatejs-types';
-import typeElement from '../../../src/type/element';
 
 describe('api/init', function () {
   let tagName;
@@ -41,68 +38,20 @@ describe('api/init', function () {
   });
 
   describe('duplication', function () {
-    function assertType (type, expected, tagToExtend) {
-      it(type + (tagToExtend ? `:${tagToExtend}` : ''), function () {
-        var { safe: tagName } = helperElement();
-        var calls = 0;
+    it('should not initialise a single component more than once on a single element', function () {
+      var calls = 0;
+      var {safe: tagName} = helperElement('my-element');
 
-        skate(tagName, {
-          type: type,
-          extends: tagToExtend,
-          created () { ++calls; }
-        });
-
-        calls = 0;
-        var el1 = document.createElement(tagName);
-        skate.init(el1);
-        expect(calls).to.equal(expected[0], tagName);
-
-        calls = 0;
-        var el2 = document.createElement('div');
-        el2.setAttribute('is', tagName);
-        skate.init(el2);
-        expect(calls).to.equal(expected[1], `div[is="${tagName}"]`);
-
-        calls = 0;
-        var el3 = document.createElement('div');
-        el3.setAttribute(tagName, '');
-        skate.init(el3);
-        expect(calls).to.equal(expected[2], `div[${tagName}]`);
-
-        calls = 0;
-        var el4 = document.createElement('div');
-        el4.className = tagName;
-        skate.init(el4);
-        expect(calls).to.equal(expected[3], `div.${tagName}`);
+      skate(tagName, {
+        created: function () {
+          ++calls;
+        }
       });
-    }
 
-    describe(':', function () {
-      assertType(typeElement,   [1, 0, 0, 0]);
-      assertType(typeAttribute, [0, 0, 1, 0]);
-      assertType(typeClass,     [0, 0, 0, 1]);
-      assertType(typeElement,   [0, 1, 0, 0], 'div');
-      assertType(typeAttribute, [0, 0, 1, 0], 'div');
-      assertType(typeClass,     [0, 0, 0, 1], 'div');
-      assertType(typeElement,   [0, 0, 0, 0], 'span');
-      assertType(typeAttribute, [0, 0, 0, 0], 'span');
-      assertType(typeClass,     [0, 0, 0, 0], 'span');
-
-      it('should not initialise a single component more than once on a single element', function () {
-        var calls = 0;
-        var {safe: tagName} = helperElement('my-element');
-
-        skate(tagName, {
-          created: function () {
-            ++calls;
-          }
-        });
-
-        var el = skate.create(tagName);
-        el.setAttribute(tagName, '');
-        el.className = tagName;
-        expect(calls).to.equal(1);
-      });
+      var el = skate.create(tagName);
+      expect(calls).to.equal(1);
+      skate.init(el);
+      expect(calls).to.equal(1);
     });
   });
 

--- a/test/unit/constructor.js
+++ b/test/unit/constructor.js
@@ -1,8 +1,6 @@
 import helperElement from '../lib/element';
 import resolved from '../lib/resolved';
 import skate from '../../src/index';
-import { attribute as typeAttribute } from 'skatejs-types';
-import { classname as typeClass } from 'skatejs-types';
 
 describe('constructor', function () {
   var id;
@@ -41,38 +39,6 @@ describe('constructor', function () {
     expect(resolved(ctor)).to.equal(true);
     expect(ctor.tagName.toLowerCase()).to.equal('span');
     expect(ctor.getAttribute('is')).to.equal(id);
-  });
-
-  it('attributes', function () {
-    var Ctor = skate(id, { type: typeAttribute });
-    var ctor = new Ctor();
-    expect(resolved(ctor)).to.equal(true);
-    expect(ctor.tagName.toLowerCase()).to.equal('div');
-    expect(ctor.getAttribute(id)).to.equal('');
-  });
-
-  it('attributes + extends', function () {
-    var Ctor = skate(id, { type: typeAttribute, extends: 'span' });
-    var ctor = new Ctor();
-    expect(resolved(ctor)).to.equal(true);
-    expect(ctor.tagName.toLowerCase()).to.equal('span');
-    expect(ctor.getAttribute(id)).to.equal('');
-  });
-
-  it('classes', function () {
-    var Ctor = skate(id, { type: typeClass });
-    var ctor = new Ctor();
-    expect(resolved(ctor)).to.equal(true);
-    expect(ctor.tagName.toLowerCase()).to.equal('div');
-    expect(ctor.getAttribute('class')).to.equal(id);
-  });
-
-  it('classes + extends', function () {
-    var Ctor = skate(id, { type: typeClass, extends: 'span' });
-    var ctor = new Ctor();
-    expect(resolved(ctor)).to.equal(true);
-    expect(ctor.tagName.toLowerCase()).to.equal('span');
-    expect(ctor.getAttribute('class')).to.equal(id);
   });
 
   it('without new operator', function () {

--- a/test/unit/dom.js
+++ b/test/unit/dom.js
@@ -3,9 +3,7 @@
 import helperElement from '../lib/element';
 import helperFixture from '../lib/fixture';
 import helperReady from '../lib/ready';
-import helperResolved from '../lib/resolved';
 import skate from '../../src/index';
-import { classname as typeClass } from 'skatejs-types';
 
 describe('dom', function () {
   describe('General DOM node interaction.', function () {
@@ -98,19 +96,22 @@ describe('dom', function () {
   describe('SVG', function () {
     it('should work for any SVG element', function () {
       var tag = helperElement().safe;
-      var html = `
-        <svg width="100" height="100">
-          <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
-          <circle class="${tag}" cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
-        </svg>
-      `;
+      var calls = 0;
 
       skate(tag, {
-        type: typeClass
+        created () {
+          calls++;
+        }
       });
 
-      skate.init(helperFixture(html));
-      expect(helperResolved(helperFixture().querySelector(`.${tag}`))).to.equal(true);
+      skate.fragment(`
+        <svg width="100" height="100">
+          <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+          <${tag}></${tag}>
+        </svg>
+      `);
+
+      expect(calls).to.equal(1);
     });
   });
 

--- a/test/unit/dom.js
+++ b/test/unit/dom.js
@@ -105,9 +105,13 @@ describe('dom', function () {
       });
 
       skate.fragment(`
-        <svg width="100" height="100">
-          <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
-          <${tag}></${tag}>
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <circle />
+          <foreignObject class="node">
+            <body xmlns="http://www.w3.org/1999/xhtml">
+              <${tag}></${tag}>
+            </body>
+          </foreignOject>
         </svg>
       `);
 

--- a/test/unit/dom.js
+++ b/test/unit/dom.js
@@ -101,17 +101,15 @@ describe('dom', function () {
       skate(tag, {
         created () {
           calls++;
-        }
+        },
+        extends: 'path',
+        prototype: Object.create(SVGElement.prototype)
       });
 
       skate.fragment(`
-        <svg xmlns="http://www.w3.org/2000/svg">
+        <svg>
           <circle />
-          <foreignObject class="node">
-            <body xmlns="http://www.w3.org/1999/xhtml">
-              <${tag}></${tag}>
-            </body>
-          </foreignOject>
+          <path is="${tag}" />
         </svg>
       `);
 
@@ -132,7 +130,6 @@ describe('dom', function () {
         created: function () {
           created = true;
         },
-
         attached: function () {
           attached = true;
         }
@@ -145,6 +142,7 @@ describe('dom', function () {
 
       frag.appendChild(myEl);
       skate.init(frag);
+
       expect(created).to.equal(true);
       expect(attached).to.equal(false);
     });

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -2,8 +2,6 @@ import helperElement from '../lib/element';
 import helperFixture from '../lib/fixture';
 import helperReady from '../lib/ready';
 import skate from '../../src/index';
-import { attribute as typeAttribute } from 'skatejs-types';
-import { classname as typeClass } from 'skatejs-types';
 
 describe('lifecycle', function () {
   var MyEl;
@@ -177,27 +175,6 @@ describe('lifecycle scenarios', function () {
     });
   });
 
-  describe('multiple bindings', function () {
-    it('should initialise all bindings', function () {
-      var id1 = helperElement('my-el');
-      var id2 = helperElement('my-el');
-      var created = 0;
-      var attached = 0;
-      var def = {
-        type: typeAttribute,
-        created: function () { ++created; },
-        attached: function () { ++attached; }
-      };
-
-      skate(id1.safe, def);
-      skate(id2.safe, def);
-
-      skate.init(helperFixture(`<div ${id1.safe} ${id2.safe}></div>`));
-      expect(created).to.equal(2, 'created');
-      expect(attached).to.equal(2, 'attached');
-    });
-  });
-
   describe('timing', function () {
     it('should call lifecycle callbacks at appropriate times.', function (done) {
       var created = false;
@@ -283,19 +260,26 @@ describe('lifecycle scenarios', function () {
     it('should not throw an error if using an id with the same name as a method / property on the Object prototype', function () {
       const idsToSkate = ['hasOwnProperty', 'watch'];
       const idsToCheck = [];
-      const div = document.createElement('div');
-      div.className = idsToSkate.join(' ');
 
       idsToSkate.forEach(function (id) {
+        const div = document.createElement('div');
+        div.className = idsToSkate.join(' ');
+
         skate(id, {
-          type: typeClass,
+          type: {
+            create () {},
+            reduce (elem, defs) {
+              return Object.prototype.hasOwnProperty.call(defs, elem.className) && defs[elem.className];
+            }
+          },
           created () {
             idsToCheck.push(id);
           }
         });
+
+        skate.fragment(`<div class="${id}"></div>`);
       });
 
-      skate.init(div);
       expect(idsToCheck).to.deep.equal(idsToSkate);
     });
   });

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -2,8 +2,6 @@
 
 import helperElement from '../lib/element';
 import skate from '../../src/index';
-import { attribute as typeAttribute } from 'skatejs-types';
-import { classname as typeClass } from 'skatejs-types';
 
 describe('Registration', function () {
   it('should not allow you to register the same component more than once.', function () {
@@ -105,34 +103,6 @@ describe('Returning a constructor', function () {
     expect(called).to.equal(true);
   });
 
-  it('should merge prototype functions if an element is skated more than once', function () {
-    var { safe: tagName } = helperElement('my-el');
-
-    var Element = skate(tagName, {
-      prototype: {
-        func1:  function () {
-          return true;
-        }
-      }
-    });
-
-    var element = new Element();
-    var { safe: attrName } = helperElement('my-attr');
-    element.setAttribute(attrName, '');
-    skate(attrName, {
-      type: typeAttribute,
-      prototype: {
-        func2:  function () {
-          return true;
-        }
-      }
-    });
-    skate.init(element);
-
-    expect(element.func1).to.be.a('function');
-    expect(element.func2).to.be.a('function');
-  });
-
   describe('when an extends option is specified', function () {
     var Div;
     var div;
@@ -181,19 +151,13 @@ describe('Native document.registerElement', function () {
   });
 
   it('should not be called if it is not compatible with tags', function () {
-    var { safe: tagName1 } = helperElement('my-element');
-    var { safe: tagName2 } = helperElement('my-element');
-
-    skate(tagName1, {
-      type: typeAttribute
+    var elem = helperElement('my-element').skate({
+      type: {
+        create () {},
+        reduce () {}
+      }
     });
-
-    skate(tagName2, {
-      type: typeClass
-    });
-
-    expect(tagName1 in definitions).to.equal(false);
-    expect(tagName2 in definitions).to.equal(false);
+    expect(elem.id in definitions).to.equal(false);
   });
 
   it('should throw an error if the tag name is invalid', function () {

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -1,9 +1,8 @@
 'use strict';
 
+import helperElement from '../lib/element';
 import registry from '../../src/shared/registry';
 import typeElement from '../../src/type/element';
-import { attribute as typeAttribute } from 'skatejs-types';
-import { classname as typeClass } from 'skatejs-types';
 
 describe('registry', function () {
   it('should set definitions', function () {
@@ -17,23 +16,14 @@ describe('registry', function () {
   });
 
   it('should return definitions for a given element', function () {
-    const definition1 = { type: typeElement };
-    const definition2 = { type: typeAttribute };
-    const definition3 = { type: typeClass };
-    const element = document.createElement('test1');
+    const definition = { type: typeElement };
+    const name = helperElement().safe;
+    const element = document.createElement(name);
 
-    element.setAttribute('test2', '');
-    element.className = 'test3';
+    registry.set(name, definition);
 
-    registry.set('test1', definition1);
-    registry.set('test2', definition2);
-    registry.set('test3', definition3);
+    const reduced = registry.find(element);
 
-    const definitions = registry.find(element);
-
-    expect(definitions.length).to.equal(3);
-    expect(definitions).to.contain(definition1, 'element');
-    expect(definitions).to.contain(definition2, 'attribute');
-    expect(definitions).to.contain(definition3, 'classname');
+    expect(reduced).to.equal(definition);
   });
 });


### PR DESCRIPTION
We use to allow multiple component bindings. This brings it closer to the spec, lessens ambiguity and improves performance.

For those that want multiple bindings, create a component that applies several bindings, or write your own binding type.