### PR TITLE
#479 - Fix performance issues with skate.ready()

### DIFF
--- a/src/lifecycle/attached.js
+++ b/src/lifecycle/attached.js
@@ -3,7 +3,7 @@ import data from '../util/data';
 export default function (opts) {
   const { attached } = opts;
   return attached ? function () {
-    let info = data(this, `lifecycle/${opts.id}`);
+    let info = data(this);
     if (info.attached) return;
     info.attached = true;
     info.detached = false;

--- a/src/lifecycle/attached.js
+++ b/src/lifecycle/attached.js
@@ -3,7 +3,7 @@ import data from '../util/data';
 export default function (opts) {
   const { attached } = opts;
   return attached ? function () {
-    let info = data(this);
+    const info = data(this);
     if (info.attached) return;
     info.attached = true;
     info.detached = false;

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -50,7 +50,7 @@ export default function (opts) {
 
   // Performance critical code!
   return function () {
-    const info = data(this, `lifecycle/${opts.id}`);
+    const info = data(this);
     const resolved = this.hasAttribute(resolvedAttribute);
     const propertyDefinitions = properties ? ensurePropertyDefinitions(this, propertyFunctions) : null;
 
@@ -91,8 +91,10 @@ export default function (opts) {
       ready(this);
     }
 
-    // This is terrible for performance.
-    emit(this, readyEventName, readyEventOptions);
+    if (info.readyCallbacks) {
+      info.readyCallbacks.forEach(cb => cb());
+      info.readyCallbacks = null;
+    }
 
     if (!resolved) {
       resolve(this, opts);

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -49,8 +49,12 @@ export default function (opts) {
     const info = data(this);
     const resolved = this.hasAttribute(resolvedAttribute);
     const propertyDefinitions = properties ? ensurePropertyDefinitions(this, propertyFunctions) : null;
+    const readyCallbacks = info.readyCallbacks;
 
-    if (info.created) return;
+    if (info.created) {
+      return;
+    }
+
     info.created = true;
 
     if (!isNative) {
@@ -87,8 +91,8 @@ export default function (opts) {
       ready(this);
     }
 
-    if (info.readyCallbacks) {
-      info.readyCallbacks.forEach(cb => cb());
+    if (readyCallbacks) {
+      readyCallbacks.forEach(cb => cb());
       info.readyCallbacks = null;
     }
 

--- a/src/lifecycle/created.js
+++ b/src/lifecycle/created.js
@@ -1,5 +1,4 @@
 import data from '../util/data';
-import emit from '../api/emit';
 import eventsApplier from './events';
 import patchAttributeMethods from './patch-attribute-methods';
 import propertiesInit from './properties-init';
@@ -7,9 +6,6 @@ import propertiesCreated from './properties-created';
 import propertiesReady from './properties-ready';
 import prototypeApplier from './prototype';
 import resolve from './resolve';
-
-const readyEventName = 'skate.ready';
-const readyEventOptions = { bubbles: false, cancelable: false };
 
 // TODO Remove this when we no longer support the legacy definitions and only
 // support a superset of a native property definition.

--- a/src/lifecycle/detached.js
+++ b/src/lifecycle/detached.js
@@ -3,7 +3,7 @@ import data from '../util/data';
 export default function (opts) {
   const { detached } = opts;
   return detached ? function () {
-    let info = data(this, `lifecycle/${opts.id}`);
+    let info = data(this);
     if (info.detached) return;
     info.detached = true;
     info.attached = false;

--- a/src/lifecycle/detached.js
+++ b/src/lifecycle/detached.js
@@ -3,7 +3,7 @@ import data from '../util/data';
 export default function (opts) {
   const { detached } = opts;
   return detached ? function () {
-    let info = data(this);
+    const info = data(this);
     if (info.detached) return;
     info.detached = true;
     info.attached = false;

--- a/test/unit/api/ready.js
+++ b/test/unit/api/ready.js
@@ -20,20 +20,12 @@ describe('api/ready', function () {
     elem = document.createElement(tag);
   });
 
-  it('should fire for an element if no definitions are registered for it', function (done) {
-    ready(elem, function (shouldBeElem) {
-      expect(shouldBeElem).to.equal(elem);
-      done();
-    });
-  });
-
   it('should fire for an element when it is already ready', function (done) {
     let called = false;
 
     setup();
     initialise();
 
-    // Ensure it's called right away.
     ready(elem, () => called = true);
     expect(called).to.equal(true);
 
@@ -44,29 +36,21 @@ describe('api/ready', function () {
   });
 
   it('should fire for an element when it is eventually ready', function (done) {
-    setup();
     ready(elem, function (shouldBeElem) {
       expect(shouldBeElem).to.equal(elem);
       done();
     });
+    setup();
     initialise();
   });
 
-  it('should take multiple elements', function (done) {
-    let elements = [elem, document.createElement(unique().safe)];
-    setup();
+  it('should take an array of elements', function (done) {
+    const elements = [elem];
     ready(elements, function (shouldBeElements) {
       expect(shouldBeElements).to.equal(elements);
       done();
     });
+    setup();
     initialise();
-  });
-
-  it('should fire if no elements are passed in', function (done) {
-    let elements = [];
-    ready(elements, function (shouldBeArray) {
-      expect(shouldBeArray).to.equal(elements);
-      done();
-    });
   });
 });


### PR DESCRIPTION
Also removed spots that didn't need to use a data namespace.

Results:

44,758 -> 169,962 ops/sec (Chrome) and 146,570 opts/sec (Firefox)

This is compared to 314,351 ops/sec for the native custom element implementation (Chrome) and 89,190 ops/sec for the custom element polyfill (Firefox).

Breaking changes are that this only now calls the callback for component elements. It used to fire for any element by checking to see if it had a component definition. However this causes problems because you may not have registered the element yet and don't want the callback to fire until you do. You can't have both. It also simplifies the behaviour of this function and you should only be passing in component elements anyways.