### PR TITLE
chore(bower): remove install step from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ node_js: '0.12'
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-- npm install -g bower
 - npm install
-- bower install
 script:
 - npm run lint
 - if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]; then


### PR DESCRIPTION
as we got rid of all direct bower dependencies, the `bower` install step is not needed any more in the travis build.