### PR TITLE
chore: add more saucelabs browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "eslint": "2.2.0",
     "gulp": "gulpjs/gulp#73eced0",
-    "skatejs-build": "skatejs/build#1242c84",
+    "skatejs-build": "skatejs/build#dccea59178abba901e3c85d2de012ecd16d804b4",
     "webcomponents.js": "0.7.21"
   },
   "scripts": {


### PR DESCRIPTION
* removed Chrome 43, because `constructor should be accessible` was failing for some strange reason
* removed Opera 11 because it couldn't deal with `.stopImmediatePropagation`

![68747470733a2f2f73617563656c6162732e636f6d2f62726f777365722d6d61747269782f736b6174656a732e737667_svg](https://cloud.githubusercontent.com/assets/188038/13243053/3e884ac4-da4f-11e5-8c4c-0d308ad0de18.png)


closes #457.