### PR TITLE
fix(globals): do not share globals between skate versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "eslint": "1.10.1",
-    "skatejs-build": "skatejs/build#15656c8",
+    "skatejs-build": "skatejs/build#skate-014-build",
     "skatejs-types": "skatejs/types#1e9725b",
     "webcomponents.js": "0.7.18"
   },

--- a/src/global/vars.js
+++ b/src/global/vars.js
@@ -1,4 +1,6 @@
-const VERSION = '__skate_0_14_0';
+import version from '../api/version';
+
+const VERSION = `__skate_${version.replace(/[^\w]/g, '_')}`;
 
 if (!window[VERSION]) {
   window[VERSION] = {


### PR DESCRIPTION
This fixes #493 for 0.14.x

refs #494 #495 

@treshugart @jpnelson @seancurtis PTAL