### PR TITLE
Edge existing attr mutation poc

### DIFF
--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -40,15 +40,6 @@
     return nativeMatchesSelector.call(element, selector);
   };
 
-  // Edge MutationObserver is polyfilled because Edge has a bug where the
-  // MutationRecord provided when removeAttribute is called has an incorrect
-  // oldValue of null rather than the previous attribute value. This Edge
-  // polyfill can be removed when http://jsbin.com/nirofo works.
-  var isEdge = /Edge/.test(navigator.userAgent);
-  if (isEdge && hasOwn(window, "JsMutationObserver") && !window.JsMutationObserver._isPolyfilled) {
-    window.MutationObserver = window.JsMutationObserver;
-  }
-
   /**
    * Parses an event definition and returns information about it.
    *

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -40,6 +40,15 @@
     return nativeMatchesSelector.call(element, selector);
   };
 
+  // Edge MutationObserver is polyfilled because Edge has a bug where the
+  // MutationRecord provided when removeAttribute is called has an incorrect
+  // oldValue of null rather than the previous attribute value. This Edge
+  // polyfill can be removed when http://jsbin.com/nirofo works.
+  var isEdge = /Edge/.test(navigator.userAgent);
+  if (isEdge && window.hasOwn("JsMutationObserver") && !JsMutationObserver._isPolyfilled) {
+    window.MutationObserver = window.JsMutationObserver;
+  }
+
   /**
    * Parses an event definition and returns information about it.
    *

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -45,7 +45,7 @@
   // oldValue of null rather than the previous attribute value. This Edge
   // polyfill can be removed when http://jsbin.com/nirofo works.
   var isEdge = /Edge/.test(navigator.userAgent);
-  if (isEdge && window.hasOwn("JsMutationObserver") && !JsMutationObserver._isPolyfilled) {
+  if (isEdge && hasOwn(window, "JsMutationObserver") && !JsMutationObserver._isPolyfilled) {
     window.MutationObserver = window.JsMutationObserver;
   }
 

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -45,7 +45,7 @@
   // oldValue of null rather than the previous attribute value. This Edge
   // polyfill can be removed when http://jsbin.com/nirofo works.
   var isEdge = /Edge/.test(navigator.userAgent);
-  if (isEdge && hasOwn(window, "JsMutationObserver") && !JsMutationObserver._isPolyfilled) {
+  if (isEdge && hasOwn(window, "JsMutationObserver") && !window.JsMutationObserver._isPolyfilled) {
     window.MutationObserver = window.JsMutationObserver;
   }
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -199,16 +199,10 @@ function addAttributeListeners (target, component) {
       var name = mutation.attributeName;
       var attr = attrs[name];
 
-      // Edge doesn't pass the mutation.oldValue value when an attribute is
-      // removed for skated elements, which causes the attribute fallback
-      // handler to be called instead of the removed handler.
-      // The commented part of the next line seems to fix things in AUI (but not the failing test).
-      var oldValue = mutation.oldValue; //(mutation.oldValue === null && attr === undefined) ? '' : mutation.oldValue;
-
       triggerAttributeChanged(target, component, {
         name: name,
         newValue: attr && (attr.value || attr.nodeValue),
-        oldValue: oldValue
+        oldValue: mutation.oldValue
       });
     });
   });

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -39,7 +39,7 @@ var matchesSelector = function (element, selector) {
 // oldValue of null rather than the previous attribute value. This Edge
 // polyfill can be removed when http://jsbin.com/nirofo works.
 const isEdge = /Edge/.test(navigator.userAgent);
-if (isEdge && window.hasOwn('JsMutationObserver') && !JsMutationObserver._isPolyfilled) {
+if (isEdge && hasOwn(window, 'JsMutationObserver') && !JsMutationObserver._isPolyfilled) {
   window.MutationObserver = window.JsMutationObserver;
 }
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -199,10 +199,16 @@ function addAttributeListeners (target, component) {
       var name = mutation.attributeName;
       var attr = attrs[name];
 
+      // Edge doesn't pass the mutation.oldValue value when an attribute is
+      // removed for skated elements, which causes the attribute fallback
+      // handler to be called instead of the removed handler.
+      // The commented part of the next line seems to fix things in AUI (but not the failing test).
+      var oldValue = mutation.oldValue; //(mutation.oldValue === null && attr === undefined) ? '' : mutation.oldValue;
+
       triggerAttributeChanged(target, component, {
         name: name,
         newValue: attr && (attr.value || attr.nodeValue),
-        oldValue: mutation.oldValue
+        oldValue: oldValue
       });
     });
   });

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -132,7 +132,9 @@ function triggerAttributeChanged(target, component, data) {
 
   // Read the old attribute value from cache if needed, otherwise use native oldValue
   var cachedAttributes;
-  if (needsAttrCaching) cachedAttributes = hasOwn(target, '_cachedAttrs') && target._cachedAttrs;
+  if (needsAttrCaching) {
+    cachedAttributes = hasOwn(target, '_cachedAttrs') && target._cachedAttrs;
+  }
   var oldValue = needsAttrCaching && hasOwn(cachedAttributes, name) ? cachedAttributes[name] : data.oldValue;
 
   var newValueIsString = typeof newValue === 'string';
@@ -149,10 +151,10 @@ function triggerAttributeChanged(target, component, data) {
   }
 
   if (needsAttrCaching) {
-    if (type == 'created' || type == 'updated') {
+    if (type === 'created' || type === 'updated') {
       cachedAttributes[name] = newValue;
-    } else if (type == 'removed' && hasOwn(cachedAttributes, name)) {
-      delete cachedAttributes[name]
+    } else if (type === 'removed' && hasOwn(cachedAttributes, name)) {
+      delete cachedAttributes[name];
     }
   }
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -34,6 +34,15 @@ var matchesSelector = function (element, selector) {
   return nativeMatchesSelector.call(element, selector);
 };
 
+// Edge MutationObserver is polyfilled because Edge has a bug where the
+// MutationRecord provided when removeAttribute is called has an incorrect
+// oldValue of null rather than the previous attribute value. This Edge
+// polyfill can be removed when http://jsbin.com/nirofo works.
+const isEdge = /Edge/.test(navigator.userAgent);
+if (isEdge && window.hasOwn('JsMutationObserver') && !JsMutationObserver._isPolyfilled) {
+  window.MutationObserver = window.JsMutationObserver;
+}
+
 /**
  * Parses an event definition and returns information about it.
  *

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -39,7 +39,7 @@ var matchesSelector = function (element, selector) {
 // oldValue of null rather than the previous attribute value. This Edge
 // polyfill can be removed when http://jsbin.com/nirofo works.
 const isEdge = /Edge/.test(navigator.userAgent);
-if (isEdge && hasOwn(window, 'JsMutationObserver') && !JsMutationObserver._isPolyfilled) {
+if (isEdge && hasOwn(window, 'JsMutationObserver') && !window.JsMutationObserver._isPolyfilled) {
   window.MutationObserver = window.JsMutationObserver;
 }
 

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -343,7 +343,6 @@ if (typeof WeakMap === "undefined") {
       clearRecords();
     }
   };
-
   global.JsMutationObserver = JsMutationObserver;
   if (!global.MutationObserver) {
     global.MutationObserver = JsMutationObserver;

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -344,13 +344,8 @@ if (typeof WeakMap === "undefined") {
     }
   };
 
-  // Edge MutationObserver is polyfilled because Edge has a bug where the
-  // MutationRecord provided when removeAttribute is called has an incorrect
-  // oldValue of null rather than the previous attribute value. This Edge
-  // polyfill can be removed when http://jsbin.com/nirofo works.
-  const isEdge = /Edge/.test(navigator.userAgent);
   global.JsMutationObserver = JsMutationObserver;
-  if (!global.MutationObserver || isEdge) {
+  if (!global.MutationObserver) {
     global.MutationObserver = JsMutationObserver;
     JsMutationObserver._isPolyfilled = true;
   }

--- a/src/mutation-observer.js
+++ b/src/mutation-observer.js
@@ -343,8 +343,14 @@ if (typeof WeakMap === "undefined") {
       clearRecords();
     }
   };
+
+  // Edge MutationObserver is polyfilled because Edge has a bug where the
+  // MutationRecord provided when removeAttribute is called has an incorrect
+  // oldValue of null rather than the previous attribute value. This Edge
+  // polyfill can be removed when http://jsbin.com/nirofo works.
+  const isEdge = /Edge/.test(navigator.userAgent);
   global.JsMutationObserver = JsMutationObserver;
-  if (!global.MutationObserver) {
+  if (!global.MutationObserver || isEdge) {
     global.MutationObserver = JsMutationObserver;
     JsMutationObserver._isPolyfilled = true;
   }

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -206,6 +206,37 @@ describe('Attribute listeners', function () {
         });
       }
 
+      function assertAttributeChangesForExistingAttr (element) {
+        helpers.afterMutations(function () {
+          element.setAttribute('test', 'updated');
+          helpers.afterMutations(function () {
+            element.removeAttribute('test');
+          });
+        });
+      }
+
+      function createAttributeDefinitionForExistingAttr (done) {
+        return {
+          test: {
+            created: function (element, data) {
+              console.log('created', JSON.stringify(data));
+              expect(data.oldValue).to.equal(null, 'oldValue should be null during create');
+              expect(data.newValue).to.equal('', 'newValue should be blank during create');
+            },
+            updated: function (element, data) {
+              console.log('updated', JSON.stringify(data));
+              expect(data.oldValue).to.equal('', 'oldValue should be blank during update');
+              expect(data.newValue).to.equal('updated', 'newValue should be "updated" during update');
+            },
+            removed: function (element, data) {
+              expect(data.oldValue).to.equal('updated', 'oldValue should be "updated" during remove');
+              expect(data.newValue).to.equal(null, 'newValue should be null during remove');
+              done();
+            }
+          }
+        };
+      }
+
       it('for native custom elements', function (done) {
         var Element = skate(helpers.safeTagName('my-el').safe, {
           attributes: createAttributeDefinition(done)
@@ -222,6 +253,16 @@ describe('Attribute listeners', function () {
         });
 
         assertAttributeChanges(helpers.fixture(`<${id}></${id}>`).querySelector(id));
+      });
+
+      it('for existing elements with existing attributes (via mutation observer)', function (done) {
+        var { safe: id } = helpers.safeTagName('element');
+
+        skate(id, {
+          attributes: createAttributeDefinitionForExistingAttr(done)
+        });
+
+        assertAttributeChangesForExistingAttr(helpers.fixture(`<${id} test></${id}>`).querySelector(id));
       });
 
       it('for attributes (via mutation observer)', function (done) {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -148,10 +148,12 @@ describe('Attribute listeners', function () {
 
     it('should call removed when the attribute is set to "undefined".', function (done) {
       myEl.testLifecycle = true;
-      myEl.testLifecycle = undefined;
       helpers.afterMutations(function () {
-        expect(removed).to.equal(true);
-        done();
+        myEl.testLifecycle = undefined;
+        helpers.afterMutations(function () {
+          expect(removed).to.equal(true);
+          done();
+        });
       });
     });
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -219,12 +219,10 @@ describe('Attribute listeners', function () {
         return {
           test: {
             created: function (element, data) {
-              console.log('created', JSON.stringify(data));
               expect(data.oldValue).to.equal(null, 'oldValue should be null during create');
               expect(data.newValue).to.equal('', 'newValue should be blank during create');
             },
             updated: function (element, data) {
-              console.log('updated', JSON.stringify(data));
               expect(data.oldValue).to.equal('', 'oldValue should be blank during update');
               expect(data.newValue).to.equal('updated', 'newValue should be "updated" during update');
             },


### PR DESCRIPTION
- just Edge. Chrome, IE, FF all fine.
- Plus a hacky lifecycle fix for AUI but still need to fix failing test

The new test is the only one that fails on Edge - it describes an existing element with an existing attribute. I may be missing something in the skate definition but the failing test is consistent with the failing tests i'm seeing in AUI 5.9.x which is based on the same 0.13.x skate branch (but please let me know the definition needs extra config)