### PR TITLE
Readme example added missed colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ JavaScript
 ```js
 skate('x-hello', {
   props: {
-    name { attribute: true }
+    name: { attribute: true }
   },
   render (elem) {
     skate.vdom.text(`Hello, ${elem.name}`);


### PR DESCRIPTION
Babel gave error on this, apology if that some new javascript syntax though... like ES2222 no colons in object declarations :P