### PR TITLE
#619 - Remove version module and tests.

### DIFF
--- a/src/api/version.js
+++ b/src/api/version.js
@@ -1,1 +1,0 @@
-export default '0.15.3';

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import factory from './api/factory';
 import link from './api/link';
 import ready from './api/ready';
 import state from './api/state';
-import version from './api/version';
 
 export {
   define,
@@ -19,5 +18,4 @@ export {
   state,
   symbols,
   vdom,
-  version
 };

--- a/test/unit.js
+++ b/test/unit.js
@@ -20,4 +20,3 @@ import './unit/vdom/events';
 import './unit/vdom/incremental-dom';
 import './unit/vdom/properties';
 import './unit/vdom/shadow-dom';
-import './unit/version';

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -46,8 +46,4 @@ describe('exports', function () {
   it('vdom', function () {
     expect(api.vdom).to.be.an('object');
   });
-
-  it('skate.version', function () {
-    expect(api.version).to.be.a('string');
-  });
 });

--- a/test/unit/version.js
+++ b/test/unit/version.js
@@ -1,9 +1,0 @@
-'use strict';
-
-import { version } from '../../src/index';
-
-describe('version', function () {
-  it('should be exposed', function () {
-    expect(version).to.be.a('string');
-  });
-});


### PR DESCRIPTION
The build doesn't bump this anymore and it doesn't make sense when consumed via a package manager
because it's in the package manifest already. It only makes sense in a global world which is quickly
going away.

BREAKING CHANGE: remove version module #619