### PR TITLE
#654 - Fix vdom.element() when passing a string as the second argument

### DIFF
--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -114,7 +114,7 @@ function newElementVoid (...args) {
 export function element (tname, attrs, chren) {
   const atype = typeof attrs;
 
-  if (atype === 'function') {
+  if (atype === 'function' || atype === 'string') {
     chren = attrs;
   }
   

--- a/test/unit/vdom/elements.js
+++ b/test/unit/vdom/elements.js
@@ -4,7 +4,88 @@ import fixture from '../../lib/fixture';
 import { shadowDomV0, shadowDomV1 } from '../../../src/util/support';
 import { symbols, vdom } from '../../../src/index';
 
-describe('vdom/elements', function () {
+describe('vdom/elements', () => {
+  describe('element()', () => {
+    describe('arguments', () => {
+      function create(render) {
+        return new (element().skate({ render }))();
+      }
+
+      function ctor(name) {
+        const Ctor = () => {};
+        Ctor[symbols.name] = name;
+        return Ctor;
+      }
+
+      it('(tagName)', () => {
+        const elem = create(() => vdom.element('div'));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+      });
+
+      it('(Constructor)', () => {
+        const Ctor = ctor('div'); 
+        const elem = create(() => vdom.element(Ctor));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+      });
+
+      it('(tagName, textContent)', () => {
+        const elem = create(() => vdom.element('div', 'text'));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('(tagName, childrenFunction)', () => {
+        const elem = create(() => vdom.element('div', vdom.text.bind(null, 'text')));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('(Contructor, textContent)', () => {
+        const Ctor = ctor('div');
+        const elem = create(() => vdom.element(Ctor, 'text'));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('(Contructor, childrenFunction)', () => {
+        const Ctor = ctor('div');
+        const elem = create(() => vdom.element(Ctor, vdom.text.bind(null, 'text')));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('tagName, attrsObject, textContent', () => {
+        const elem = create(() => vdom.element('div', { id: 'test' }, 'text'));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('tagName, attrsObject, childrenFunction', () => {
+        const elem = create(() => vdom.element('div', { id: 'test' }, vdom.text.bind(null, 'text')));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('Constructor, attrsObject, textContent', () => {
+        const Ctor = ctor('div');
+        const elem = create(() => vdom.element(Ctor, { id: 'test' }, 'text'));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+
+      it('Constructor, attrsObject, childrenFunction', () => {
+        const Ctor = ctor('div');
+        const elem = create(() => vdom.element(Ctor, { id: 'test' }, vdom.text.bind(null, 'text')));
+        expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV');
+        expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test');
+        expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text');
+      });
+    });
+  });
+
   it('slot', function () {
     const elem1 = new (element().skate({
       render () {
@@ -39,7 +120,7 @@ describe('vdom/elements', function () {
     }
   });
 
-  it('passing a component constructor to the vdom.element() function', function (done) {
+  it('passing a component constructor to the vdom.element() function', done => {
     const Elem1 = element().skate({
       render () {
         vdom.element('div', function () {


### PR DESCRIPTION
Fixes #654.