### PR TITLE
#564, #663 - Multiple components with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Without native support and if you do not supply a Shadow DOM polyfill, any compo
       - [Background](#background)
     - [`state (elem[, state])`](#state-elem-state)
     - [`symbols`](#symbols)
-      - [`shadowRoot`](#shadowroot)
+      - [`$name`](#name)
+      - [`$shadowRoot`](#shadowroot)
     - [`vdom`](#vdom)
       - [`vdom.element (elementName, attributesOrChildren, children)`](#vdomelement-elementname-attributesorchildren-children)
       - [`vdom.text (text)`](#vdomtext-text)
@@ -150,6 +151,7 @@ Without native support and if you do not supply a Shadow DOM polyfill, any compo
     - [Compatible with multiple versions of itself](#compatible-with-multiple-versions-of-itself)
     - [Properties and Attributes](#properties-and-attributes)
   - [React Integration](#react-integration)
+  - [Multiple Component Names and Hot Module Reloading (a.k.a. Webpack HMR)](#multiple-component-names-and-hot-module-reloading-aka-webpack-hmr)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1016,7 +1018,15 @@ state(elem);
 
 Symbols are exposed for you to access information that stored on objects that are not otherwise accessible.
 
-#### `shadowRoot`
+
+
+#### `$name`
+
+The `$name` symbol can be used to retrieve the tag name of the component from the constructor. This will be the tag name the component was registerd with. If the component has been re-registered with a unique name (see [Multiple Component Names and Hot Module Reloading (a.k.a. Webpack HMR)](#multiple-component-names-and-hot-module-reloading-aka-webpack-hmr)) then this will be the unique name.
+
+
+
+#### `$shadowRoot`
 
 When a component renders for the first time, it creates a new shadow root - if it can - and stores this shadow root on the element using this symbol. If a shadow root cannot be created, this returns the element itself.
 
@@ -1372,3 +1382,16 @@ skate.define('my-component', {
 ## React Integration
 
 We provide an [integration layer](https://github.com/skatejs/react-integration) for React that transforms your web components into React components so that they can be used as first-class citizens within React.
+
+
+
+## Multiple Component Names and Hot Module Reloading (a.k.a. Webpack HMR)
+
+Skate is designed to work with hot-modoule reloading out of the box:
+
+- It will always use the canonical name on the initial registration
+- Subsequent registrations will register using the canonical name with a number suffix to identify how many times it's been registered
+
+*Skate cannot refresh the component definition as there is no way to reregister a component using the web component APIs.*
+
+While this makes the name non-deterministic, you can still get the name from the constructor if you need to using the [`$name` symbol](#name).

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,5 +1,6 @@
 import './boot';
 import './unit/index';
+import './unit/api/define';
 import './unit/api/emit';
 import './unit/api/properties';
 import './unit/api/ready';

--- a/test/unit/api/define.js
+++ b/test/unit/api/define.js
@@ -1,0 +1,21 @@
+import { Component, define, symbols } from '../../../src/index';
+
+describe('api/define', () => {
+  it('should register components with unique names', () => {
+    expect(define('x-test-api-define', {})[symbols.name]).to.equal('x-test-api-define');
+    expect(define('x-test-api-define', {})[symbols.name]).to.equal('x-test-api-define-1');
+    expect(define('x-test-api-define', {})[symbols.name]).to.equal('x-test-api-define-2');
+  });
+
+  it('should take an object and extend Component', () => {
+    expect(define('x-test', {}).prototype).to.be.an.instanceof(Component);
+  });
+
+  it('should be able to take an ES5 extension of Comonent', () => {
+    expect(define('x-test', {}).prototype).to.be.an.instanceof(Component);
+  });
+
+  it('should take a constructor that extends Component', () => {
+    expect(define('x-test', class extends Component {}).prototype).to.be.an.instanceof(Component);
+  });
+});

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -1,23 +1,6 @@
 import { define } from '../../src/index';
 import helperElement from '../lib/element';
 
-describe('Registration', function () {
-  it('should not allow you to register the same component more than once.', function () {
-    var multiple = false;
-    var tag = helperElement('my-el');
-    define(tag.safe, {});
-
-    try {
-      define(tag.safe, {});
-      multiple = true;
-    } catch (e) {
-      // Do nothing
-    }
-
-    assert(!multiple);
-  });
-});
-
 describe('Returning a constructor', function () {
   it('should return a constructor that extends a native element.', function () {
     var tag = helperElement('my-el');


### PR DESCRIPTION
If a component with the same name has already been registered, Skate will use the specified name as  a prefix and append a number to the name before registering it.

Fixes #564 and implements #663.