### PR TITLE
fix: fixed native polyfill detection

### DIFF
--- a/src/util/support.js
+++ b/src/util/support.js
@@ -13,24 +13,22 @@ export const v1ShadowDOMProperty = 'attachShadow';
 export function shouldUseShadowDomV0(elem) {
   if (isNative(elem, v1ShadowDOMProperty)) {
     return false;
-  } else if (isPolyfill(elem, v1ShadowDOMProperty) && isNative(elem, v0ShadowDOMProperty)) {
+  } else if (isNative(elem, v0ShadowDOMProperty)) {
     return true;
-  } else if (!isPolyfill(elem, v1ShadowDOMProperty) && isNative(elem, v0ShadowDOMProperty)) {
-    return true;
-  } else {
+  } else if (isPolyfill(elem, v1ShadowDOMProperty)) {
     return false;
+  } else {
+    return isPolyfill(elem, v0ShadowDOMProperty);
   }
 }
 
 export function shouldUseShadowDomV1(elem) {
   if (isNative(elem, v1ShadowDOMProperty)) {
     return true;
-  } else if (isPolyfill(elem, v1ShadowDOMProperty) && isNative(elem, v0ShadowDOMProperty)) {
+  } else if (isNative(elem, v0ShadowDOMProperty)) {
     return false;
-  } else if (isPolyfill(elem, v1ShadowDOMProperty)) {
-    return true;
   } else {
-    return false;
+    return isPolyfill(elem, v1ShadowDOMProperty);
   }
 }
 

--- a/test/unit/util/support.js
+++ b/test/unit/util/support.js
@@ -5,7 +5,7 @@ describe('util/support', () => {
     // We take a copy of a known native property so that we can mock how our code will behave when
     // it finds a native implementation of a function. The polyfilled property just needs to match
     // what a non-native property looks like on an element (must have a `value` function)
-    const nativeProperty = Object.getOwnPropertyDescriptor(Element.prototype, 'getAttribute');
+    const nativeProperty = Object.getOwnPropertyDescriptor(Function.prototype, 'toString');
     const polyfilledProperty = { value: () => {}};
 
     let obj;
@@ -44,6 +44,6 @@ describe('util/support', () => {
       expect(shouldUseShadowDomV0(obj)).to.equal(false);
       expect(shouldUseShadowDomV1(obj)).to.equal(true);
     });
-  });  
+  });
 });
 


### PR DESCRIPTION
Changed to the `Function.prototype` in `nativeProperty`, since webcomponents shadowDOM polyfill polyfillng everything and old approach didn't work as expected.

`shouldUseShadowDomV0` and `shouldUseShadowDomV1 ` became simpler.