### PR TITLE
#679 - Fix props being passed to function helpers when calling Incremental DOM directly

### DIFF
--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -102,11 +102,11 @@ function resolveTagName (tname) {
 
 function wrapIdomFunc (func, tnameFuncHandler = () => {}) {
   return function wrap (...args) {
-    const tname = args[0] = resolveTagName(args[0]);
-    if (typeof tname === 'function') {
+    args[0] = resolveTagName(args[0]);
+    if (typeof args[0] === 'function') {
       // If we've encountered a function, handle it according to the type of
       // function that is being wrapped.
-      return tnameFuncHandler(tname);
+      return tnameFuncHandler(...args);
     } else if (stackChren.length) {
       // We pass the wrap() function in here so that when it's called as
       // children, it will queue up for the next stack, if there is one.
@@ -126,9 +126,13 @@ function newAttr (key, val) {
   }
 }
 
-function stackOpen () {
+function stackOpen (tname, key, statics, ...attrs) {
+  const props = {};
+  for (let a = 0; a < attrs.length; a += 2) {
+    props[attrs[a]] = attrs[a + 1];
+  }
   stackChren.push([]);
-  stackProps.push({});
+  stackProps.push(props);
 }
 
 function stackClose (tname) {
@@ -137,9 +141,9 @@ function stackClose (tname) {
   return tname(props, () => chren.forEach(args => args[0](...args[1])));
 }
 
-function stackVoid (tname) {
-  stackOpen();
-  return stackClose(tname);
+function stackVoid (...args) {
+  stackOpen(...args);
+  return stackClose(args[0]);
 }
 
 // Convenience function for declaring an Incremental DOM element using

--- a/test/unit/vdom/incremental-dom.js
+++ b/test/unit/vdom/incremental-dom.js
@@ -21,9 +21,9 @@ describe('IncrementalDOM', function () {
     let fixture;
     beforeEach(() => fixture = document.createElement('div'));
 
-    function patchAssert(elem, { checkChildren = true }) {
+    function patchAssert(elem, { checkChildren = true } = {}) {
       expect(fixture.firstChild).to.equal(elem);
-      expect(fixture.innerHTML).to.equal(`<div id="test">${ checkChildren ? '<span>test</span>' : '</div>'}`);
+      expect(fixture.innerHTML).to.equal(`<div id="test">${ checkChildren ? '<span>test</span>' : ''}</div>`);
     }
 
     function patchIt(desc, func) {
@@ -37,8 +37,7 @@ describe('IncrementalDOM', function () {
     }
 
     const Elem = (props, chren) => {
-      const elem = vdom.elementOpen('div', null, null);
-      Object.keys(props).forEach(prop => vdom.attr(prop, props[prop]));
+      const elem = vdom.elementOpen('div', null, null, 'id', props.id);
       chren();
       vdom.elementClose('div');
       return elem;

--- a/test/unit/vdom/incremental-dom.js
+++ b/test/unit/vdom/incremental-dom.js
@@ -17,7 +17,7 @@ describe('IncrementalDOM', function () {
   testBasicApi('elementVoid');
   testBasicApi('text');
 
-  describe.only('passing a function helper', () => {
+  describe('passing a function helper', () => {
     let fixture;
     beforeEach(() => fixture = document.createElement('div'));
 

--- a/test/unit/vdom/incremental-dom.js
+++ b/test/unit/vdom/incremental-dom.js
@@ -17,38 +17,49 @@ describe('IncrementalDOM', function () {
   testBasicApi('elementVoid');
   testBasicApi('text');
 
-  describe('passing a function helper', () => {
+  describe.only('passing a function helper', () => {
     let fixture;
     beforeEach(() => fixture = document.createElement('div'));
 
-    function patchAssert(elem) {
+    function patchAssert(elem, { checkChildren = true }) {
       expect(fixture.firstChild).to.equal(elem);
-      expect(fixture.innerHTML).to.equal('<div id="test"></div>');
+      expect(fixture.innerHTML).to.equal(`<div id="test">${ checkChildren ? '<span>test</span>' : '</div>'}`);
     }
 
     function patchIt(desc, func) {
       it(desc, () => IncrementalDOM.patch(fixture, func));
     }
 
-    const Elem = () => {
-      const elem = vdom.elementOpen('div', null, null, 'id', 'test');
+    function renderChildren() {
+      vdom.elementOpen('span');
+      vdom.text('test');
+      vdom.elementClose('span');
+    }
+
+    const Elem = (props, chren) => {
+      const elem = vdom.elementOpen('div', null, null);
+      Object.keys(props).forEach(prop => vdom.attr(prop, props[prop]));
+      chren();
       vdom.elementClose('div');
       return elem;
     };
 
     patchIt('elementOpen, elementClose', () => {
-      vdom.elementOpen(Elem);
+      vdom.elementOpen(Elem, null, null, 'id', 'test');
+      renderChildren();
       patchAssert(vdom.elementClose(Elem));
     });
 
-    patchIt('elementOpenStart, elementOpenEnd, elementClose', () => {
-      vdom.elementOpenStart(Elem);
+    patchIt('elementOpenStart, attr, elementOpenEnd, elementClose', () => {
+      vdom.elementOpenStart(Elem, null, null);
+      vdom.attr('id', 'test');
       vdom.elementOpenEnd(Elem);
+      renderChildren();
       patchAssert(vdom.elementClose(Elem));
     });
     
     patchIt('elementVoid', () => {
-      patchAssert(vdom.elementVoid(Elem));
+      patchAssert(vdom.elementVoid(Elem, null, null, 'id', 'test'), { checkChildren: false });
     });
   });
 });


### PR DESCRIPTION
Fixes #679.

Something that we're not doing yet is passing `key` and `statics` on to helpers. This would increase the number of arguments, else we can create a generic object to pass in to the helper instead. Currently the API shape looks like:

```js
const Helper = (props, chren) => {};
```

With `key` and `statics` added:

```js
const Helper = (props, chren, key, statics) => {};
```

We could combine them:

```js
const Helper = (props, chren, { key, statics }) => {};
```

Pass them as `props`:

```js
const Helper = ({ key, statics, ...props }, chren) => {};
```

Or do everything together:

```js
const Helper = ({ key, statics, props, children }) => {};
```