### PR TITLE
fix: attributeChanged fixed

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -72,13 +72,12 @@ export default class Component extends HTMLElement {
       // then that causes the attribute to be set again.
       if (propData.syncingAttribute) {
         propData.syncingAttribute = false;
-        return;
+      } else {
+        // Sync up the property.
+        const propOpts = this.constructor.props[propertyName];
+        propData.settingAttribute = true;
+        this[propertyName] = newValue !== null && propOpts.deserialize ? propOpts.deserialize(newValue) : newValue;
       }
-
-      // Sync up the property.
-      const propOpts = this.constructor.props[propertyName];
-      propData.settingAttribute = true;
-      this[propertyName] = newValue !== null && propOpts.deserialize ? propOpts.deserialize(newValue) : newValue;
     }
 
     if (attributeChanged) {

--- a/test/unit/lifecycle/attribute-changed.js
+++ b/test/unit/lifecycle/attribute-changed.js
@@ -1,5 +1,6 @@
 import element from '../../lib/element';
 import fixture from '../../lib/fixture';
+import afterMutations from '../../lib/after-mutations';
 
 describe('lifecycle/attribute-changed', function () {
   it('should make arguments to attributeChanged consistent with the rest of the callbacks', function (done) {
@@ -17,5 +18,25 @@ describe('lifecycle/attribute-changed', function () {
         done();
       }
     });
+  });
+
+  it('attributes that are defined as properties should call attributeChanged callback', function (done) {
+    let counter = 0;
+    let elem = new (element().skate({
+      attributeChanged () {
+        counter++;
+      },
+      props: {
+        test: {
+          attribute: true
+        },
+      },
+    }));
+    afterMutations(done);
+    expect(counter).to.equal(0);
+    elem.test = true;
+    expect(counter).to.equal(1);
+    elem.test = false;
+    expect(counter).to.equal(2);
   });
 });

--- a/test/unit/lifecycle/attribute-changed.js
+++ b/test/unit/lifecycle/attribute-changed.js
@@ -32,11 +32,13 @@ describe('lifecycle/attribute-changed', function () {
         },
       },
     }));
-    afterMutations(done);
-    expect(counter).to.equal(0);
-    elem.test = true;
-    expect(counter).to.equal(1);
-    elem.test = false;
-    expect(counter).to.equal(2);
+    afterMutations(
+      () => expect(counter).to.equal(0),
+      () => (elem.test = true),
+      () => expect(counter).to.equal(1),
+      () => (elem.test = false),
+      () => expect(counter).to.equal(2),
+      done
+    );
   });
 });

--- a/test/unit/lifecycle/attribute-changed.js
+++ b/test/unit/lifecycle/attribute-changed.js
@@ -20,9 +20,9 @@ describe('lifecycle/attribute-changed', function () {
     });
   });
 
-  it('attributes that are defined as properties should call attributeChanged callback', function (done) {
+  it('attributes that are defined as properties should call attributeChanged callback', (done) => {
     let counter = 0;
-    let elem = new (element().skate({
+    const elem = new (element().skate({
       attributeChanged () {
         counter++;
       },


### PR DESCRIPTION
According to the documentation, `The attributeChangedCallback() is invoked for every attribute that exists on the element at the time of creation.`.
But for the properties that were defined as attributes this callback was never called.
This PR is fixing it.