### PR TITLE
#721 - Fix ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,40 +49,9 @@ Whenever you change the `name` property - or attribute - the component will re-r
 
 Skate doesn't require you provide any external dependencies, but recommends you provide some web component polyfills depending on what browsers you require support for.
 
+To get up and running quickly with the most common configuration, we've created a single package called [`skatejs-web-components`](https://github.com/skatejs/web-components) where all you have to do is load it before Skate.
 
-
-### Custom Elements
-
-Skate requires Custom Element support. In [browsers that don't support it](http://caniuse.com/#search=custom%20elements), you'll need to include a polyfill.
-
-- v1: https://github.com/webcomponents/webcomponentsjs/tree/v1/src/CustomElements/v1 (recommended)
-- v0: https://github.com/webcomponents/webcomponentsjs (known issues)
-
-
-
-### Shadow DOM
-
-Skate works with or without [Shadow DOM](http://w3c.github.io/webcomponents/spec/shadow/) support. However, it works best with it so it's recommended you use a polyfill for [browsers](http://caniuse.com/#search=shadow%20dom) that don't support it natively.
-
-- v1: https://github.com/skatejs/named-slots/ (recommended)
-- v0: https://github.com/WebComponents/webcomponentsjs (known issues)
-
-Without native support and if you do not supply a Shadow DOM polyfill, any components that have a `render()` function may cause issues integrating with React and other virtual DOM-based libraries (such as Skate itself) because the shadow DOM hides changes that are made to the components during `render()`. If no Shadow DOM support is available, your component renders directly to the host element rather than to the shadow root. This means your component will work fine on its own, but may fail when composed into other libraries.
-
-
-
-### Known Issues with Polyfills
-
-The following are issues with polyfills - not native - implementations.
-
-Custom Elements V0:
-
-- Does not work with native Shadow DOM (only noticable with V1 as V0 Custom Elements and Shadow DOM shipped at the same time in Blink)
-- Static constructor properties / methods ignored (https://github.com/webcomponents/webcomponentsjs/issues/563)
-
-Shadow DOM V0:
-
-- Cannot use component constructors
+If you don't want to use that, you'll have to BYO Custom Element and Shadow DOM V1 polyfills. Skate will work without Shadow DOM support, but you won't be able to compose components together due to the lack of DOM encapsulation that Shadow DOM gives you.
 
 
 

--- a/package.json
+++ b/package.json
@@ -26,14 +26,12 @@
     "incremental-dom": "0.4.1"
   },
   "devDependencies": {
-    "birdpoo": "^0.2.2",
-    "es6-shim": "^0.35.1",
-    "eslint": "^3.2.0",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
-    "skatejs-build": "^7.0.1",
-    "skatejs-named-slots": "^1.0.0",
-    "webcomponents.js": "webcomponents/webcomponentsjs#b77ca74"
+    "birdpoo": "0.x",
+    "eslint": "3.x",
+    "react": "15.x",
+    "react-dom": "15.x",
+    "skatejs-build": "7.x",
+    "skatejs-web-components": "*"
   },
   "scripts": {
     "prepublish": "rollup --config rollup.config.js && webpack --config webpack.config.js",
@@ -43,6 +41,5 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  },
-  "version": "1.0.1"
+  }
 }

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -1,9 +1,11 @@
 import {
   applyProp,
   attributes,
+  currentElement,
   elementClose,
   elementOpen,
   elementVoid,
+  skip,
   symbols,
   text,
 } from 'incremental-dom';
@@ -75,7 +77,10 @@ attributes.ref = function (elem, name, value) {
 // Skip handler.
 attributes.skip = function (elem, name, value) {
   if (value) {
+    skip();
     elem[$skipCurrentElement] = true;
+  } else {
+    delete elem[$skipCurrentElement];
   }
 };
 
@@ -161,7 +166,9 @@ function wrapIdomFunc(func, tnameFuncHandler = () => {}) {
       const isElementClosing = func === elementClose;
       const isElementOpening = func === elementOpen;
 
-      if (skipCurrentTree && !isElementClosing) {
+      // If we're skipping the tree, we must skip everything except for the
+      // closing of the element that originally started the skipping.
+      if (skipCurrentTree && !isElementClosing && !currentElement()[$skipCurrentElement]) {
         return;
       }
 

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -4,7 +4,6 @@ import {
   elementClose,
   elementOpen,
   elementVoid,
-  skip,
   symbols,
   text,
 } from 'incremental-dom';

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -158,6 +158,11 @@ function wrapIdomFunc(func, tnameFuncHandler = () => {}) {
       const elem = func(...args);
       if (func === elementClose) {
         const eref = elem[$ref];
+
+        // We delete so that it isn't called again for the same element. If the
+        // ref changes, or the element changes, this will be defined again.
+        delete elem[$ref];
+        
         if (typeof eref === 'function') {
           eref(elem);
         }

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -62,8 +62,10 @@ attributes.checked = attributes.className = attributes.disabled = attributes.val
 // V0 Shadow DOM to V1 normalisation.
 attributes.name = function (elem, name, value) {
   if (elem.tagName === 'CONTENT') {
-    applyDefault(elem, 'select', `[slot="${value}"]`);
+    name = 'select';
+    value = `[slot="${value}"]`;
   }
+  applyDefault(elem, 'name', value);
 };
 
 // Ref handler.

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -158,7 +158,6 @@ function wrapIdomFunc(func, tnameFuncHandler = () => {}) {
       const elem = func(...args);
       if (func === elementClose) {
         const eref = elem[$ref];
-        delete elem[$ref];
         if (typeof eref === 'function') {
           eref(elem);
         }

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -65,7 +65,7 @@ attributes.name = function (elem, name, value) {
     name = 'select';
     value = `[slot="${value}"]`;
   }
-  applyDefault(elem, 'name', value);
+  applyDefault(elem, name, value);
 };
 
 // Ref handler.

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -177,15 +177,15 @@ function wrapIdomFunc(func, tnameFuncHandler = () => {}) {
       if (isElementOpening && elem[$skipCurrentElement]) {
         skipCurrentTree = true;
       } else if (isElementClosing) {
-        const eref = elem[$ref];
+        const ref = elem[$ref];
 
         // We delete so that it isn't called again for the same element. If the
         // ref changes, or the element changes, this will be defined again.
         delete elem[$ref];
 
         // Execute the saved ref after esuring we've cleand up after it.
-        if (typeof eref === 'function') {
-          eref(elem);
+        if (typeof ref === 'function') {
+          ref(elem);
         }
 
         // If this element was skipped, we should stop skipping the tree since

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,18 +1,10 @@
-const div = document.createElement('div');
-const reqCustomElements = require.context('../node_modules/webcomponents.js/src/CustomElements/v1', true, /^\.\/CustomElements\.js$/);
-const reqNamedSlots = require.context('../node_modules/skatejs-named-slots/dist', true, /^.*\.js$/);
 const reqTests = require.context('./unit', true, /^.*\.js$/);
 
 if (!document.registerElement && !window.customElements) {
-  require('webcomponents.js/src/WeakMap/WeakMap');
-  require('webcomponents.js/src/MutationObserver/MutationObserver');
-  require('es6-shim'); // For Map()
-  reqCustomElements('./CustomElements.js');
-}
-
-if (!div.createShadowRoot && !div.attachShadow) {
-  reqNamedSlots('./index.js');
+  /* eslint import/no-extraneous-dependencies: 0 */
+  require('skatejs-web-components');
 }
 
 require('./boot');
+
 reqTests.keys().map(reqTests);

--- a/test/unit/vdom/ref.js
+++ b/test/unit/vdom/ref.js
@@ -2,7 +2,7 @@ import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
 import { define, prop, props, vdom } from '../../../src/index';
 
-describe('vdom/ref', () => {
+function test(name, el) {
   function create(ref) {
     const Elem = define('x-test', {
       props: {
@@ -10,7 +10,7 @@ describe('vdom/ref', () => {
         ref: { initial: () => ref },
       },
       render(elem) {
-        vdom.element('div', { ref: elem.ref, id: 'div' }, () =>
+        vdom.element(el, { ref: elem.ref, id: 'div' }, () =>
           vdom.element('span', { id: 'span' }, 'test')
         );
       },
@@ -20,65 +20,79 @@ describe('vdom/ref', () => {
     return elem;
   }
 
-  it('should be a function', done => {
-    create(() => done());
-  });
+  describe(name, () => {
+    it('should be a function', done => {
+      create(() => done());
+    });
 
-  it('should have access to all properties', done => {
-    create(node => {
-      expect(node.id).to.equal('div');
-      done();
+    it('should have access to all properties', done => {
+      create(node => {
+        expect(node.id).to.equal('div');
+        done();
+      });
+    });
+
+    it('should have access to all descendants', done => {
+      create(node => {
+        expect(node.firstChild.tagName).to.equal('SPAN');
+        expect(node.firstChild.id).to.equal('span');
+        expect(node.firstChild.textContent).to.equal('test');
+        done();
+      });
+    });
+
+    it('should be called on every re-render', done => {
+      let num = 0;
+      const elem = create(() => ++num);
+      afterMutations(() => {
+        expect(num).to.equal(1);
+        props(elem, { num: num + 1 });
+        expect(num).to.equal(2);
+        props(elem, { num: num + 1 });
+        expect(num).to.equal(3);
+        done();
+      });
+    });
+
+    it('should call a different ref if changed', done => {
+      let ref1;
+      let ref2;
+      const elem = create(() => {
+        ref1 = true;
+      });
+      afterMutations(() => {
+        expect(ref1).to.equal(true);
+        expect(ref2).to.equal(undefined);
+        props(elem, { ref: () => {
+          ref2 = true;
+        } });
+        expect(ref1).to.equal(true);
+        expect(ref2).to.equal(true);
+        done();
+      });
+    });
+
+    it('should not call a removed ref', done => {
+      let num = 0;
+      const elem = create(() => ++num);
+      afterMutations(() => {
+        expect(num).to.equal(1);
+        props(elem, { ref: null });
+        expect(num).to.equal(1);
+        done();
+      });
     });
   });
+}
 
-  it('should have access to all descendants', done => {
-    create(node => {
-      expect(node.firstChild.tagName).to.equal('SPAN');
-      expect(node.firstChild.id).to.equal('span');
-      expect(node.firstChild.textContent).to.equal('test');
-      done();
-    });
-  });
-
-  it('should be called on every re-render', done => {
-    let num = 0;
-    const elem = create(() => ++num);
-    afterMutations(() => {
-      expect(num).to.equal(1);
-      props(elem, { num: num + 1 });
-      expect(num).to.equal(2);
-      props(elem, { num: num + 1 });
-      expect(num).to.equal(3);
-      done();
-    });
-  });
-
-  it('should call a different ref if changed', done => {
-    let ref1;
-    let ref2;
-    const elem = create(() => {
-      ref1 = true;
-    });
-    afterMutations(() => {
-      expect(ref1).to.equal(true);
-      expect(ref2).to.equal(undefined);
-      props(elem, { ref: () => {
-        ref2 = true;
-      } });
-      expect(ref1).to.equal(true);
-      expect(ref2).to.equal(true);
-      done();
-    });
-  });
-
-  it('should not call a removed ref', done => {
-    let num = 0;
-    const elem = create(() => ++num);
-    afterMutations(() => {
-      expect(num).to.equal(1);
-      props(elem, { ref: null });
-      expect(num).to.equal(1);
-      done();
-    });
+describe('vdom/ref', () => {
+  test('normal elements', 'div');
+  test('custom elements', define('x-test', {
+    render() {
+      vdom.element('slot');
+    }
+  }));
+  test('function helpers', (props, chren) => {
+    vdom.element('div', props, chren);
   });
 });

--- a/test/unit/vdom/ref.js
+++ b/test/unit/vdom/ref.js
@@ -45,11 +45,14 @@ function test(name, el) {
       let num = 0;
       const ref = () => ++num;
       const elem = create(ref);
+
+      // We change elem.num here so that we can see what happens when we
+      // re-render without changing the ref.
       afterMutations(
         () => expect(num).to.equal(1),
-        () => props(elem, { ref }),
+        () => props(elem, { num: elem.num + 1 }),
         () => expect(num).to.equal(1),
-        () => props(elem, { ref: () => ++num }),
+        () => props(elem, { num: elem.num + 2, ref: () => ++num }),
         () => expect(num).to.equal(2),
         done
       );

--- a/test/unit/vdom/ref.js
+++ b/test/unit/vdom/ref.js
@@ -41,35 +41,18 @@ function test(name, el) {
       });
     });
 
-    it('should be called on every re-render', done => {
+    it('should only call a ref if it changes', done => {
       let num = 0;
-      const elem = create(() => ++num);
-      afterMutations(() => {
-        expect(num).to.equal(1);
-        props(elem, { num: num + 1 });
-        expect(num).to.equal(2);
-        props(elem, { num: num + 1 });
-        expect(num).to.equal(3);
-        done();
-      });
-    });
-
-    it('should call a different ref if changed', done => {
-      let ref1;
-      let ref2;
-      const elem = create(() => {
-        ref1 = true;
-      });
-      afterMutations(() => {
-        expect(ref1).to.equal(true);
-        expect(ref2).to.equal(undefined);
-        props(elem, { ref: () => {
-          ref2 = true;
-        } });
-        expect(ref1).to.equal(true);
-        expect(ref2).to.equal(true);
-        done();
-      });
+      const ref = () => ++num;
+      const elem = create(ref);
+      afterMutations(
+        () => expect(num).to.equal(1),
+        () => props(elem, { ref }),
+        () => expect(num).to.equal(1),
+        () => props(elem, { ref: () => ++num }),
+        () => expect(num).to.equal(2),
+        done
+      );
     });
 
     it('should not call a removed ref', done => {

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -32,7 +32,7 @@ describe('vdom/skip', () => {
     }
     const Elem = define('x-test', {
       props: {
-        num: prop.number()
+        num: prop.number({ default: 2 })
       },
       render(elem) {
         vdom.element('div', { skip: !isEven(elem.num) }, () => {
@@ -45,15 +45,15 @@ describe('vdom/skip', () => {
     const elem = new Elem();
     fixture(elem);
     afterMutations(
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('0'),
-      () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('0'),
-      () => props(elem, { num: elem.num + 1 }),
       () => expect(elem[symbols.shadowRoot].textContent).to.equal('2'),
       () => props(elem, { num: elem.num + 1 }),
       () => expect(elem[symbols.shadowRoot].textContent).to.equal('2'),
       () => props(elem, { num: elem.num + 1 }),
       () => expect(elem[symbols.shadowRoot].textContent).to.equal('4'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('4'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('6'),
       done
     );
   });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -4,24 +4,23 @@ import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
   it('should skip the element children', done => {
-    // const Elem = define('x-test', {
-    //   props: {
-    //     num: prop.number()
-    //   },
-    //   render() {
-    //     vdom.element('div', { skip: true }, () => {
-    //       vdom.text('text');
-    //     });
-    //   },
-    // });
-    // const elem = new Elem();
-    // fixture(elem);
-    // afterMutations(
-    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
-    //   () => props(elem, { num: elem.num + 1 }),
-    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
-    //   done
-    // );
-    done();
+    const Elem = define('x-test', {
+      props: {
+        num: prop.number()
+      },
+      render() {
+        vdom.element('div', { skip: true }, () => {
+          vdom.text('text');
+        });
+      },
+    });
+    const elem = new Elem();
+    fixture(elem);
+    afterMutations(
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      done
+    );
   });
 });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -10,7 +10,9 @@ describe('vdom/skip', () => {
       },
       render() {
         vdom.element('div', { skip: true }, () => {
-          vdom.text('text');
+          vdom.element('span', () => {
+            vdom.text('text');
+          });
         });
       },
     });
@@ -20,6 +22,38 @@ describe('vdom/skip', () => {
       () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
       () => props(elem, { num: elem.num + 1 }),
       () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      done
+    );
+  });
+
+  it('should allow conditional rendering', done => {
+    function isEven(num) {
+      return num % 2 === 0;
+    }
+    const Elem = define('x-test', {
+      props: {
+        num: prop.number()
+      },
+      render(elem) {
+        vdom.element('div', { skip: !isEven(elem.num) }, () => {
+          vdom.element('span', () => {
+            vdom.text(elem.num);
+          });
+        });
+      },
+    });
+    const elem = new Elem();
+    fixture(elem);
+    afterMutations(
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('0'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('0'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('2'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('2'),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('4'),
       done
     );
   });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -1,20 +1,24 @@
-import { define, symbols, vdom } from '../../../src/index';
+import { define, prop, props, symbols, vdom } from '../../../src/index';
 import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
-  it('should skip the element children', done => {
+  it.only('should skip the element children', done => {
+    const ref = e => (e.textContent = 'real');
     const Elem = define('x-test', {
-      render() {
-        vdom.element('div', { skip: true }, () => {
-          vdom.text('test');
-        });
+      props: {
+        test: prop.number()
+      },
+      render(elem) {
+        vdom.element('div', { ref, skip: true });
       },
     });
     const elem = new Elem();
     fixture(elem);
     afterMutations(
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
+      () => props(elem, { test: 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
       done
     );
   });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -4,28 +4,25 @@ import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
   it('should skip the element children', done => {
-    // const ref = e => (e.textContent = 'real');
-    // const Elem = define('x-test', {
-    //   props: {
-    //     test: prop.number()
-    //   },
-    //   render(elem) {
-    //     vdom.element('div', { ref, skip: true });
-    //   },
-    // });
-    // const elem = new Elem();
-    // fixture(elem);
-    // afterMutations(
-    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-    //   () => props(elem, { test: 1 }),
-    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-    //   done
-    // );
-    done();
-  });
-
-  it('should still execute ref', () => {
-
+    const ref = e => (e.textContent = 'real');
+    const Elem = define('x-test', {
+      props: {
+        test: prop.number()
+      },
+      render() {
+        vdom.element('div', { ref, skip: true, id: 'test' });
+      },
+    });
+    const elem = new Elem();
+    fixture(elem);
+    afterMutations(
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
+      () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
+      () => props(elem, { test: 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
+      () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
+      done
+    );
   });
 
   it('should still set attributes', () => {
@@ -33,6 +30,6 @@ describe('vdom/skip', () => {
   });
 
   it('should work with custom elements', () => {
-    
+
   });
 });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -1,0 +1,33 @@
+import { define, symbols, vdom } from '../../../src/index';
+import afterMutations from '../../lib/after-mutations';
+import fixture from '../../lib/fixture';
+
+describe('vdom/skip', () => {
+  it('should skip the element children', done => {
+    const Elem = define('x-test', {
+      render() {
+        vdom.element('div', { skip: true }, () => {
+          vdom.text('test');
+        });
+      },
+    });
+    const elem = new Elem();
+    fixture(elem);
+    afterMutations(
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      done
+    );
+  });
+
+  it('should still execute ref', () => {
+
+  });
+
+  it('should still set attributes', () => {
+
+  });
+
+  it('should work with custom elements', () => {
+    
+  });
+});

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -4,23 +4,24 @@ import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
   it('should skip the element children', done => {
-    const Elem = define('x-test', {
-      props: {
-        num: prop.number()
-      },
-      render() {
-        vdom.element('div', { skip: true }, () => {
-          vdom.text('text');
-        });
-      },
-    });
-    const elem = new Elem();
-    fixture(elem);
-    afterMutations(
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
-      () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
-      done
-    );
+    // const Elem = define('x-test', {
+    //   props: {
+    //     num: prop.number()
+    //   },
+    //   render() {
+    //     vdom.element('div', { skip: true }, () => {
+    //       vdom.text('text');
+    //     });
+    //   },
+    // });
+    // const elem = new Elem();
+    // fixture(elem);
+    // afterMutations(
+    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+    //   () => props(elem, { num: elem.num + 1 }),
+    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+    //   done
+    // );
+    done();
   });
 });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -3,24 +3,25 @@ import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
-  it.only('should skip the element children', done => {
-    const ref = e => (e.textContent = 'real');
-    const Elem = define('x-test', {
-      props: {
-        test: prop.number()
-      },
-      render(elem) {
-        vdom.element('div', { ref, skip: true });
-      },
-    });
-    const elem = new Elem();
-    fixture(elem);
-    afterMutations(
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-      () => props(elem, { test: 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-      done
-    );
+  it('should skip the element children', done => {
+    // const ref = e => (e.textContent = 'real');
+    // const Elem = define('x-test', {
+    //   props: {
+    //     test: prop.number()
+    //   },
+    //   render(elem) {
+    //     vdom.element('div', { ref, skip: true });
+    //   },
+    // });
+    // const elem = new Elem();
+    // fixture(elem);
+    // afterMutations(
+    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
+    //   () => props(elem, { test: 1 }),
+    //   () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
+    //   done
+    // );
+    done();
   });
 
   it('should still execute ref', () => {

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -4,32 +4,23 @@ import fixture from '../../lib/fixture';
 
 describe('vdom/skip', () => {
   it('should skip the element children', done => {
-    const ref = e => (e.textContent = 'real');
     const Elem = define('x-test', {
       props: {
-        test: prop.number()
+        num: prop.number()
       },
       render() {
-        vdom.element('div', { ref, skip: true, id: 'test' });
+        vdom.element('div', { skip: true }, () => {
+          vdom.text('text');
+        });
       },
     });
     const elem = new Elem();
     fixture(elem);
     afterMutations(
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-      () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
-      () => props(elem, { test: 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('real'),
-      () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
+      () => props(elem, { num: elem.num + 1 }),
+      () => expect(elem[symbols.shadowRoot].textContent).to.equal(''),
       done
     );
-  });
-
-  it('should still set attributes', () => {
-
-  });
-
-  it('should work with custom elements', () => {
-
   });
 });


### PR DESCRIPTION
Fixes #721 and #724.

Some minor refactors to simplify the default attribute handler.

Fixed `ref` so that it will only be called if the element changes or if the ref changes. if you specify a closure in `render()` it will always change. If you supply a function that doesn't change, it will only ever be called if the element is re-rendered.

Fixed `skip` so that it actually skips the entire tree. Incremental DOM requires that you either `skip()` or render your tree. Providing this API is syntactic sugar for not having to worry about `if / else` blocks and makes it more declarative. This is being provided as a fix as it was originally intended to work this way, but was broken.

See this [bin](http://jsbin.com/yaralol/12/edit) for how you'd do it with IDOM.