### PR TITLE
fix(emit): Fix emit behaviour so that it's consistent with all browsers.

### DIFF
--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -25,5 +25,5 @@ export default function (elem, name, opts = {}) {
   if (opts.cancelable === undefined) {
     opts.cancelable = true;
   }
-  return elem.disabled ? true : elem.dispatchEvent(createCustomEvent(name, opts));
+  return elem.dispatchEvent(createCustomEvent(name, opts));
 }

--- a/test/unit/api/emit.js
+++ b/test/unit/api/emit.js
@@ -4,18 +4,12 @@ import fixture from '../../lib/fixture';
 describe('api/emit', () => {
   let child;
   let parent;
-  let disabled;
   let triggered;
 
   beforeEach(() => {
     child = document.createElement('child');
-
-    disabled = document.createElement('button');
-    disabled.setAttribute('disabled', '');
-
     parent = document.createElement('parent');
     parent.appendChild(child);
-    parent.appendChild(disabled);
 
     triggered = 0;
 
@@ -24,7 +18,6 @@ describe('api/emit', () => {
     child.addEventListener('test', () => ++triggered);
     child.addEventListener('test', e => e.preventDefault());
     parent.addEventListener('test', () => ++triggered);
-    disabled.addEventListener('test', () => ++triggered);
 
     // It's not spec'd whether or not detached elements should bubble. In some
     // they do, in some they don't. We ensure they do by adding the nodes to
@@ -35,12 +28,6 @@ describe('api/emit', () => {
   it('string eventName', () => {
     emit(parent, 'test');
     expect(triggered).to.equal(1);
-  });
-
-  it('disabled element', () => {
-    const canceled = !emit(disabled, 'test');
-    expect(triggered).to.equal(0);
-    expect(canceled).to.equal(false);
   });
 
   it('undefined eventOptions', () => {


### PR DESCRIPTION
Firefox still has a bug regarding this issue. This also fixes a problem where we couldn't emit

events on any elements (custom elements) that have a "disabled" property and this is absolutely

something that people need to do.

Fixes #726.