### PR TITLE
Fix linked attribute going out of sync

### DIFF
--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -94,13 +94,16 @@ function createNativePropertyDefinition(name, opts) {
 
     // Link up the attribute.
     const attributeName = data(this, 'propertyLinks')[name];
-    if (attributeName && !propData.settingAttribute && valueHasChanged) {
+    if (attributeName && !propData.settingAttribute) {
       const serializedValue = opts.serialize(newValue);
       propData.syncingAttribute = true;
       if (shouldRemoveAttribute || empty(serializedValue)) {
         this.removeAttribute(attributeName);
       } else {
         this.setAttribute(attributeName, serializedValue);
+      }
+      if (!valueHasChanged && propData.syncingAttribute) {
+        propData.syncingAttribute = false;
       }
     }
 

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -79,6 +79,7 @@ function createNativePropertyDefinition(name, opts) {
     propData.internalValue = newValue;
 
     const changeData = { name, newValue, oldValue };
+    const valueHasChanged = newValue !== oldValue;
 
     if (typeof opts.set === 'function') {
       opts.set(this, changeData);
@@ -93,7 +94,7 @@ function createNativePropertyDefinition(name, opts) {
 
     // Link up the attribute.
     const attributeName = data(this, 'propertyLinks')[name];
-    if (attributeName && !propData.settingAttribute) {
+    if (attributeName && !propData.settingAttribute && valueHasChanged) {
       const serializedValue = opts.serialize(newValue);
       propData.syncingAttribute = true;
       if (shouldRemoveAttribute || empty(serializedValue)) {

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -120,10 +120,6 @@ describe('lifecycle/property', () => {
 
       it('setting the property to the existing value, then setting the attribute updates the property', done => {
         const elem = create({ attribute: true }, 'testName', 'something');
-
-        expect(elem.testName).to.equal('something');
-        expect(elem.getAttribute('test-name')).to.equal('something');
-
         elem.testName = 'something';
 
         expect(elem.testName).to.equal('something');
@@ -136,6 +132,19 @@ describe('lifecycle/property', () => {
           done();
         });
       });
+
+      it('setting the property to null twice, and then setting the attribute updates the property', done => {
+        const elem = create({ attribute: true });
+        elem.testName = null;
+
+        elem.setAttribute('test-name', 'something');
+        afterMutations(() => {
+          expect(elem.testName).to.equal('something');
+          expect(elem.getAttribute('test-name')).to.equal('something');
+          done();
+        });
+      });
+
 
       describe('undefined and null', () => {
         it('when a string, the value is used as the attribute name', () => {

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -104,6 +104,39 @@ describe('lifecycle/property', () => {
         expect(elem.getAttribute('test-name')).to.equal('something else');
       });
 
+      it('setting the attribute updates the property value', done => {
+        const elem = create({ attribute: true }, 'testName', 'something');
+
+        expect(elem.testName).to.equal('something');
+        expect(elem.getAttribute('test-name')).to.equal('something');
+
+        elem.setAttribute('test-name', 'something else');
+        afterMutations(() => {
+          expect(elem.testName).to.equal('something else');
+          expect(elem.getAttribute('test-name')).to.equal('something else');
+          done();
+        });
+      });
+
+      it('setting the property to the existing value, then setting the attribute updates the property', done => {
+        const elem = create({ attribute: true }, 'testName', 'something');
+
+        expect(elem.testName).to.equal('something');
+        expect(elem.getAttribute('test-name')).to.equal('something');
+
+        elem.testName = 'something';
+
+        expect(elem.testName).to.equal('something');
+        expect(elem.getAttribute('test-name')).to.equal('something');
+
+        elem.setAttribute('test-name', 'something else');
+        afterMutations(() => {
+          expect(elem.testName).to.equal('something else');
+          expect(elem.getAttribute('test-name')).to.equal('something else');
+          done();
+        });
+      });
+
       describe('undefined and null', () => {
         it('when a string, the value is used as the attribute name', () => {
           const elem = create({ attribute: 'test-name' });


### PR DESCRIPTION
Setting a property to the same value twice and then trying to set the linked attribute will not update the property in native (Chrome + Chrome Canary).

This is because the second time the property setter is run, trying to set the linked attribute to the same value won't trigger the `attributeChangedCallback` callback.