### PR TITLE
fix: Fix for setting a linked attribute not updating the property

### DIFF
--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -79,7 +79,6 @@ function createNativePropertyDefinition(name, opts) {
     propData.internalValue = newValue;
 
     const changeData = { name, newValue, oldValue };
-    const valueHasChanged = newValue !== oldValue;
 
     if (typeof opts.set === 'function') {
       opts.set(this, changeData);
@@ -96,13 +95,16 @@ function createNativePropertyDefinition(name, opts) {
     const attributeName = data(this, 'propertyLinks')[name];
     if (attributeName && !propData.settingAttribute) {
       const serializedValue = opts.serialize(newValue);
+      const currentAttrValue = this.getAttribute(attributeName);
+      const attributeChanged = !((empty(serializedValue) && empty(currentAttrValue)) ||
+                                (serializedValue === currentAttrValue));
       propData.syncingAttribute = true;
       if (shouldRemoveAttribute || empty(serializedValue)) {
         this.removeAttribute(attributeName);
       } else {
         this.setAttribute(attributeName, serializedValue);
       }
-      if (!valueHasChanged && propData.syncingAttribute) {
+      if (!attributeChanged && propData.syncingAttribute) {
         propData.syncingAttribute = false;
       }
     }

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -96,10 +96,11 @@ function createNativePropertyDefinition(name, opts) {
     if (attributeName && !propData.settingAttribute) {
       const serializedValue = opts.serialize(newValue);
       const currentAttrValue = this.getAttribute(attributeName);
-      const attributeChanged = !((empty(serializedValue) && empty(currentAttrValue)) ||
-                                (serializedValue === currentAttrValue));
+      const serializedIsEmpty = empty(serializedValue);
+      const attributeChanged = !((serializedIsEmpty && empty(currentAttrValue)) ||
+                                 serializedValue === currentAttrValue);
       propData.syncingAttribute = true;
-      if (shouldRemoveAttribute || empty(serializedValue)) {
+      if (shouldRemoveAttribute || serializedIsEmpty) {
         this.removeAttribute(attributeName);
       } else {
         this.setAttribute(attributeName, serializedValue);

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -118,34 +118,6 @@ describe('lifecycle/property', () => {
         });
       });
 
-      it('setting the property to the existing value, then setting the attribute updates the property', done => {
-        const elem = create({ attribute: true }, 'testName', 'something');
-        elem.testName = 'something';
-
-        expect(elem.testName).to.equal('something');
-        expect(elem.getAttribute('test-name')).to.equal('something');
-
-        elem.setAttribute('test-name', 'something else');
-        afterMutations(() => {
-          expect(elem.testName).to.equal('something else');
-          expect(elem.getAttribute('test-name')).to.equal('something else');
-          done();
-        });
-      });
-
-      it('setting the property to null twice, and then setting the attribute updates the property', done => {
-        const elem = create({ attribute: true });
-        elem.testName = null;
-
-        elem.setAttribute('test-name', 'something');
-        afterMutations(() => {
-          expect(elem.testName).to.equal('something');
-          expect(elem.getAttribute('test-name')).to.equal('something');
-          done();
-        });
-      });
-
-
       describe('undefined and null', () => {
         it('when a string, the value is used as the attribute name', () => {
           const elem = create({ attribute: 'test-name' });
@@ -515,7 +487,7 @@ describe('lifecycle/property', () => {
   });
 
   describe('patterns', () => {
-    it('should allow you to do something with a set value but return a compconstely different value', () => {
+    it('should allow you to do something with a set value but return a completely different value', () => {
       let set;
       const elem2 = create({
         attribute: true,
@@ -530,6 +502,54 @@ describe('lifecycle/property', () => {
       elem2.testName = 'set';
       expect(set).to.equal('set');
       expect(elem2.testName).to.equal('get');
+    });
+
+    describe('setting the attribute updates the property correctly after the property is set', () => {
+      it('to an existing value', (done) => {
+        const elem = create({ attribute: true }, 'testName', 'something');
+        elem.testName = 'something';
+
+        expect(elem.testName).to.equal('something');
+        expect(elem.getAttribute('test-name')).to.equal('something');
+
+        elem.setAttribute('test-name', 'something else');
+        afterMutations(() => {
+          expect(elem.testName).to.equal('something else');
+          expect(elem.getAttribute('test-name')).to.equal('something else');
+          done();
+        });
+      });
+
+      it('to an existing null value', (done) => {
+        const elem = create({ attribute: true });
+        elem.testName = null;
+
+        elem.setAttribute('test-name', 'something');
+        afterMutations(() => {
+          expect(elem.testName).to.equal('something');
+          expect(elem.getAttribute('test-name')).to.equal('something');
+          done();
+        });
+      });
+
+      it('to an existing serialized value', (done) => {
+        const elem = create(({
+          attribute: true,
+          serialize: value => (value ? '' : undefined),
+          deserialize: value => (value !== null),
+        }));
+
+        elem.testName = false;
+        expect(elem.testName).to.equal(false);
+        expect(elem.getAttribute('test-name')).to.equal(null);
+
+        elem.setAttribute('test-name', '');
+        afterMutations(() => {
+          expect(elem.testName).to.equal(true);
+          expect(elem.getAttribute('test-name')).to.equal('');
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Followup to the fix for #733, check that the actual attribute value has changed after serialization

Fixes #738

---

The issue was that we were only checking that value had changed, not that the attribute value had changed (which was the root cause of the problem). We need to check that the new attribute value (i.e. `serializedValue`) is not new.

Also moved tests to a new section at the bottom of the file, and added one new test.