### PR TITLE
#742 - add support for webreflection/document-register-element

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Whenever you change the `name` property - or attribute - the component will re-r
     - [NPM](#npm)
     - [Script Tag](#script-tag)
   - [Dependencies](#dependencies)
+  - [Browser Support](#browser-support)
   - [Resources](#resources)
   - [Questions?](#questions)
   - [Terminology](#terminology)
@@ -207,7 +208,16 @@ Or you can use script tags:
 
 If you want finer grained control about which polyfills you use, you'll have to BYO Custom Element and Shadow DOM V1 polyfills. Skate will work without Shadow DOM support, but you won't be able to compose components together due to the lack of DOM encapsulation that Shadow DOM gives you.
 
-**Skate works with the native V0 APIs, however, the V0 polyfills have several bugs that are inconsistent with the native APIs, so it's not recommended you try and use the V0 polyfills.** 
+**Skate works with the native V0 APIs, however, the V0 polyfills have several bugs that are inconsistent with the native APIs, so it's not recommended you try and use the V0 polyfills.**
+
+
+
+## Browser Support
+
+Skate supports all major browsers and some older versions of IE. IE support depends on which polyfills you include:
+
+- IE9+ [`skatejs-web-components`](https://github.com/skatejs/web-components) or [`document-register-element`](https://github.com/WebReflection/document-register-element) - *recommended*
+- IE11+ [`webcomponents.js`](https://github.com/webcomponents/webcomponentsjs) - only the v1 polyfill is supported
 
 
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "15.x",
     "react-dom": "15.x",
     "skatejs-build": "7.x",
-    "skatejs-web-components": "*"
+    "skatejs-web-components": "1.x"
   },
   "scripts": {
     "prepublish": "rollup --config rollup.config.js && webpack --config webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "document-register-element": "^1.0.7",
     "eslint": "3.4.0",
     "eslint-friendly-formatter": "^2.0.6",
+    "eslint-plugin-import": "^1.14.0",
     "precommit-hook": "^3.0.0",
     "react": "15.x",
     "react-dom": "15.x",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "birdpoo": "0.x",
+    "document-register-element": "^1.0.7",
     "eslint": "3.4.0",
     "eslint-friendly-formatter": "^2.0.6",
     "precommit-hook": "^3.0.0",
@@ -39,7 +40,8 @@
     "prepublish": "rollup --config rollup.config.js && webpack --config webpack.config.js",
     "test": "karma start --single-run",
     "lint": "eslint . --ext .js,.jsx --format 'node_modules/eslint-friendly-formatter'",
-    "commit": "npm run lint && git cz"
+    "commit": "npm run lint && git cz",
+    "validate": "npm ls"
   },
   "config": {
     "commitizen": {
@@ -47,6 +49,8 @@
     }
   },
   "pre-commit": [
-    "lint"
+    "lint",
+    "validate",
+    "test"
   ]
 }

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -74,8 +74,8 @@ function callDisconnected(elem) {
 
 export default class Component extends HTMLElement {
   // v1
-  constructor() {
-    const elem = super();
+  constructor(self) {
+    const elem = super(self);
     callConstructor(elem);
     return elem;
   }
@@ -120,6 +120,11 @@ export default class Component extends HTMLElement {
     if (attributeChanged) {
       attributeChanged(this, { name, newValue, oldValue });
     }
+  }
+
+  // v0
+  createdCallback() {
+    callConstructor(this);
   }
 
   // v0

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -18,7 +18,7 @@ function callConstructor(elem) {
 
   // Ensures that this can never be called twice.
   if (elem[$created]) return;
-  elem[$created] = elem;
+  elem[$created] = true;
 
   // Set up a renderer that is debounced for property sets to call directly.
   elem[$rendererDebounced] = debounce(Ctor[$renderer]);

--- a/src/api/prop.js
+++ b/src/api/prop.js
@@ -7,7 +7,7 @@ const alwaysUndefinedIfEmptyOrString = (val) => (empty(val) ? undefined : String
 export function create(def) {
   return (...args) => {
     args.unshift({}, def);
-    return assign.apply(null, args); // eslint-disable-line prefer-spread
+    return assign(...args);
   };
 }
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -2,9 +2,7 @@ const reqTests = require.context('./unit', true, /^.*\.js$/);
 
 if (!document.registerElement && !window.customElements) {
   /* eslint import/no-extraneous-dependencies: 0, global-require: 0 */
-  // require('skatejs-web-components');
-  require('skatejs-named-slots');
-  require('document-register-element/build/document-register-element.max');
+  require('skatejs-web-components');
 }
 
 require('./boot');

--- a/test/unit.js
+++ b/test/unit.js
@@ -2,7 +2,9 @@ const reqTests = require.context('./unit', true, /^.*\.js$/);
 
 if (!document.registerElement && !window.customElements) {
   /* eslint import/no-extraneous-dependencies: 0, global-require: 0 */
-  require('skatejs-web-components');
+  // require('skatejs-web-components');
+  require('skatejs-named-slots');
+  require('document-register-element/build/document-register-element.max');
 }
 
 require('./boot');

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -76,7 +76,7 @@ describe('api/prop', () => {
 
     [undefined, null, false, 0, '', 'something'].forEach((value) => {
       value = String(value);
-      it(`setting attribute to ${value}`, (done) => {
+      it(`setting attribute to ${JSON.stringify(value)}`, (done) => {
         const elem = create(prop.boolean());
         elem.setAttribute('test', value);
         afterMutations(
@@ -85,7 +85,7 @@ describe('api/prop', () => {
           done
         );
       });
-      it(`setting property to ${value}`, () => {
+      it(`setting property to "${JSON.stringify(value)}"`, () => {
         const elem = create(prop.boolean());
         elem.test = value;
         expect(elem.test).to.equal(!!value, 'property');

--- a/test/unit/extending.js
+++ b/test/unit/extending.js
@@ -1,7 +1,7 @@
 import helperElement from '../lib/element';
 import { define } from '../../src/index';
 
-describe('extending', () => {
+describe.only('extending', () => {
   let Ctor;
   let tag;
 
@@ -31,7 +31,7 @@ describe('extending', () => {
   });
 
   it('should copy all configuration options to the extended object', () => {
-    const ExtendedCtor = define(tag, class extends Ctor {});
+    const ExtendedCtor = define(tag, Ctor.extend());
     expect(ExtendedCtor.extends).to.equal('div');
     expect(ExtendedCtor.someNonStandardProperty).to.equal(true);
     expect(ExtendedCtor.created).to.be.a('function');
@@ -41,35 +41,35 @@ describe('extending', () => {
   });
 
   it('prototype members should be available', () => {
-    const ExtendedCtor = define(tag, class extends Ctor {});
+    const ExtendedCtor = define(tag, Ctor.extend());
     expect(new ExtendedCtor().test).to.equal(true);
     expect(new ExtendedCtor().someFunction).to.be.a('function');
   });
 
   it('should not mess with callbacks', () => {
-    const ExtendedCtor = define(tag, class extends Ctor {});
+    const ExtendedCtor = define(tag, Ctor.extend());
     expect(new ExtendedCtor().__test).to.equal('test');
   });
 
   it('should allow overriding of callbacks', () => {
-    const ExtendedCtor = define(tag, class extends Ctor {
-      static created(elem) {
-        super.created(elem);
+    const ExtendedCtor = define(tag, Ctor.extend({
+      created(elem) {
+        Ctor.created(elem);
         elem.__test += 'ing';
-      }
-    });
+      },
+    }));
     const elem = new ExtendedCtor();
     expect(elem.__test).to.equal('testing');
   });
 
   it('constructor should be accessible', () => {
-    const El = define(tag, class extends Ctor {});
+    const El = define(tag, Ctor.extend());
     const el = new El();
     expect(el.constructor).to.be.a('function');
     expect(el.constructor.extends).to.equal('div');
   });
 
-  it('extends()', () => {
+  it('extend()', () => {
     const Comp1 = define(`${tag}-1`, {});
     const Comp2 = define(`${tag}-2`, Comp1.extend({}));
     const elem1 = new Comp1();

--- a/test/unit/extending.js
+++ b/test/unit/extending.js
@@ -1,7 +1,9 @@
 import helperElement from '../lib/element';
 import { define } from '../../src/index';
 
-describe.only('extending', () => {
+const canSetProto = '__proto__' in document.createElement('div');
+
+describe('extending', () => {
   let Ctor;
   let tag;
 
@@ -69,14 +71,16 @@ describe.only('extending', () => {
     expect(el.constructor.extends).to.equal('div');
   });
 
-  it('extend()', () => {
-    const Comp1 = define(`${tag}-1`, {});
-    const Comp2 = define(`${tag}-2`, Comp1.extend({}));
-    const elem1 = new Comp1();
-    const elem2 = new Comp2();
-    expect(elem1).to.be.an.instanceof(Comp1);
-    expect(elem1).to.not.be.an.instanceof(Comp2);
-    expect(elem2).to.be.an.instanceof(Comp1);
-    expect(elem2).to.be.an.instanceof(Comp2);
-  });
+  if (canSetProto) {
+    it('extend()', () => {
+      const Comp1 = define(`${tag}-1`, {});
+      const Comp2 = define(`${tag}-2`, Comp1.extend({}));
+      const elem1 = new Comp1();
+      const elem2 = new Comp2();
+      expect(elem1).to.be.an.instanceof(Comp1);
+      expect(elem1).to.not.be.an.instanceof(Comp2);
+      expect(elem2).to.be.an.instanceof(Comp1);
+      expect(elem2).to.be.an.instanceof(Comp2);
+    });
+  }
 });


### PR DESCRIPTION
WIP: 

- [ ] Wait for skatejs/web-components#7 to be merged.
- [ ] Update tests testing class extension to not run in IE 9 and 10 since it doesn't support static property extension. Consumers supporting these browsers should use `.extends()` instead.
- [ ] Add IE9 and 10 to Browserstack.

Still retains support for native and the webcomponents.js v1 polyfill. Adds support for IE 9 and 10 mostly through just consuming the `document-register-element1` polyfill.