### PR TITLE
fix: Apply skate semantics to element attributes in a stack context.

### DIFF
--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -2,7 +2,7 @@ import {
   applyProp,
   attributes,
   elementClose,
-  elementOpen,
+  elementOpen as idomElementOpen,
   skip,
   symbols,
   text,
@@ -155,6 +155,10 @@ function resolveTagName(tname) {
   return tname;
 }
 
+// Incremental DOM's elementOpen is where the hooks in `attributes` are applied,
+// so it's the only function we need to execute in the context of our attributes.
+const elementOpen = attributesContext(idomElementOpen);
+
 function elementOpenStart(tag, key = null, statics = null) {
   overrideArgs = [tag, key, statics];
 }
@@ -267,7 +271,7 @@ const newElementOpenEnd = wrapIdomFunc(elementOpenEnd);
 
 // Standard open / closed overrides don't need to reproduce internal behaviour
 // because they are the ones referenced from *End and *Start.
-const newElementOpen = attributesContext(wrapIdomFunc(elementOpen, stackOpen));
+const newElementOpen = wrapIdomFunc(elementOpen, stackOpen);
 const newElementClose = wrapIdomFunc(elementClose, stackClose);
 
 // Ensure we call our overridden functions instead of the internal ones.

--- a/test/unit/vdom/properties.js
+++ b/test/unit/vdom/properties.js
@@ -16,6 +16,26 @@ describe('vdom/properties', () => {
     );
   });
 
+  it('applies custom semantics to the className attribute when used in a stack context', done => {
+    const helper = (_, children) => children();
+
+    const elem = new (define('x-test', {
+      render() {
+        vdom.elementOpen(helper);
+        vdom.elementOpen('div', null, null, 'className', 'inner');
+        vdom.elementClose('div');
+        vdom.elementClose(helper);
+      },
+    }));
+
+    fixture(elem);
+
+    afterMutations(
+      () => expect(elem[symbols.shadowRoot].firstChild.getAttribute('class')).to.equal('inner'),
+      done
+    );
+  });
+
   it('false should remove the attribute', done => {
     const elem = new (define('x-test', {
       render() {


### PR DESCRIPTION
Fixes #756