### PR TITLE
Fix case where event is not emitted outside of the shadow dom in Chrome 53 (native v1 shadow dom)

### DIFF
--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -10,11 +10,16 @@ const CustomEvent = ((Event) => {
 })(window.CustomEvent);
 
 function createCustomEvent(name, opts = {}) {
-  if (CustomEvent) {
-    return new CustomEvent(name, opts);
+  let e;
+  if (Event) {
+    e = new Event(name, opts);
+    if (opts.detail) {
+      Object.defineProperty(e, 'detail', { value: opts.detail });
+    }
+  } else {
+    e = document.createEvent('CustomEvent');
+    e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
   }
-  const e = document.createEvent('CustomEvent');
-  e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
   return e;
 }
 
@@ -24,6 +29,9 @@ export default function (elem, name, opts = {}) {
   }
   if (opts.cancelable === undefined) {
     opts.cancelable = true;
+  }
+  if (opts.composed === undefined) {
+    opts.composed = true;
   }
   return elem.dispatchEvent(createCustomEvent(name, opts));
 }

--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -13,7 +13,7 @@ function createCustomEvent(name, opts = {}) {
   let e;
   if (Event) {
     e = new Event(name, opts);
-    if (opts.detail) {
+    if ('detail' in opts) {
       Object.defineProperty(e, 'detail', { value: opts.detail });
     }
   } else {

--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -10,15 +10,18 @@ const CustomEvent = ((Event) => {
 })(window.CustomEvent);
 
 function createCustomEvent(name, opts = {}) {
+  const { detail } = opts;
+  delete opts.detail;
+
   let e;
   if (Event) {
     e = new Event(name, opts);
-    if ('detail' in opts) {
-      Object.defineProperty(e, 'detail', { value: opts.detail });
+    if (typeof detail !== 'undefined') {
+      Object.defineProperty(e, 'detail', { value: detail });
     }
   } else {
     e = document.createEvent('CustomEvent');
-    e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
+    e.initCustomEvent(name, opts.bubbles, opts.cancelable, detail);
   }
   return e;
 }

--- a/test/unit/vdom/events.js
+++ b/test/unit/vdom/events.js
@@ -73,10 +73,12 @@ describe('vdom/events (on*)', () => {
     });
   });
 
-  it('should events bubble from shadow dom', done => {
+  it('should emit events from shadow dom', done => {
     let called = false;
-    const test = () => {
+    let detail = null;
+    const test = (e) => {
       called = true;
+      detail = e.detail;
     };
     const myel = new (element().skate({
       render() {
@@ -87,8 +89,9 @@ describe('vdom/events (on*)', () => {
     fixture().appendChild(myel);
 
     afterMutations(() => {
-      emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { compose: true });
+      emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { detail: 'detail' });
       expect(called).to.equal(true);
+      expect(detail).to.equal('detail');
       done();
     });
   });

--- a/test/unit/vdom/events.js
+++ b/test/unit/vdom/events.js
@@ -73,6 +73,26 @@ describe('vdom/events (on*)', () => {
     });
   });
 
+  it('should events bubble from shadow dom', done => {
+    let called = false;
+    const test = () => {
+      called = true;
+    };
+    const myel = new (element().skate({
+      render() {
+        vdom.element('div', {}, vdom.element.bind(null, 'span'));
+      },
+    }));
+    myel.addEventListener('test', test);
+    fixture().appendChild(myel);
+
+    afterMutations(() => {
+      emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { compose: true });
+      expect(called).to.equal(true);
+      done();
+    });
+  });
+
   it('should not fail for listeners that are not functions', done => {
     const myel = new (element().skate({
       render() {


### PR DESCRIPTION
This fails for Chrome (53.0.2785), passes for Firefox (48.0.0), so needs a fix to move forward.

**DO NOT MERGE** if you want a green build. :)