### PR TITLE
fix: skip ES2015 class tests that rely on statics inheritance in IE9 and 10

### DIFF
--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -5,6 +5,7 @@ import {
 import assign from '../util/assign';
 import data from '../util/data';
 import empty from '../util/empty';
+import dashCase from '../util/dash-case';
 
 function getDefaultValue(elem, name, opts) {
   return typeof opts.default === 'function' ? opts.default(elem, { name }) : opts.default;
@@ -22,7 +23,7 @@ function createNativePropertyDefinition(name, opts) {
 
   prop.created = function (elem) { // eslint-disable-line func-names
     const propData = data(elem, `api/property/${name}`);
-    const attributeName = opts.attribute;
+    const attributeName = opts.attribute === true ? dashCase(name) : opts.attribute;
     let initialValue = elem[name];
     let shouldSyncAttribute = false;
 

--- a/test/lib/support.js
+++ b/test/lib/support.js
@@ -1,0 +1,9 @@
+// Determine if ES2015 class statics are inherited. In IE 9 and 10 this is not
+// supported. This is useful for skipping tests that require ES2015 class
+// semantics for statics.
+export function classStaticsInheritance() {
+  class Base {};
+  Base.static = 'static';
+  class Subclass extends Base {};
+  return Subclass.static === 'static';
+};

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -28,7 +28,7 @@ describe('lifecycle/property', () => {
   describe('props declared as attributes with ES2015 classes are linked', () => {
     const skip = !classStaticsInheritance();
 
-    it('uses the same attribute and property name for lower-case names', (done) => {
+    it('uses the same attribute and property name for lower-case names', function(done) {
       if (skip) this.skip();
 
       const elem = new (element().skate(class extends Component {
@@ -44,7 +44,7 @@ describe('lifecycle/property', () => {
       );
     });
 
-    it('uses the same attribute and property name for dashed-names names', (done) => {
+    it('uses the same attribute and property name for dashed-names names', function(done) {
       if (skip) this.skip();
 
       const elem = new (element().skate(class extends Component {
@@ -60,7 +60,7 @@ describe('lifecycle/property', () => {
       );
     });
 
-    it('uses a dash-cased attribute name for camel-case property names', (done) => {
+    it('uses a dash-cased attribute name for camel-case property names', function(done) {
       if (skip) this.skip();
 
       const elem = new (element().skate(class extends Component {

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -1,5 +1,6 @@
 import afterMutations from '../../lib/after-mutations';
 import element from '../../lib/element';
+import { classStaticsInheritance } from '../../lib/support';
 import propsInit from '../../../src/lifecycle/props-init';
 import { Component } from '../../../src';
 
@@ -25,7 +26,11 @@ describe('lifecycle/property', () => {
   });
 
   describe('props declared as attributes with ES2015 classes are linked', () => {
+    const skip = !classStaticsInheritance();
+
     it('uses the same attribute and property name for lower-case names', (done) => {
+      if (skip) this.skip();
+
       const elem = new (element().skate(class extends Component {
         static get props() {
           return { testprop: { attribute: true } };
@@ -40,6 +45,8 @@ describe('lifecycle/property', () => {
     });
 
     it('uses the same attribute and property name for dashed-names names', (done) => {
+      if (skip) this.skip();
+
       const elem = new (element().skate(class extends Component {
         static get props() {
           return { ['test-prop']: { attribute: true } };
@@ -54,6 +61,8 @@ describe('lifecycle/property', () => {
     });
 
     it('uses a dash-cased attribute name for camel-case property names', (done) => {
+      if (skip) this.skip();
+
       const elem = new (element().skate(class extends Component {
         static get props() {
           return { testProp: { attribute: true } };

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -1,6 +1,7 @@
 import afterMutations from '../../lib/after-mutations';
 import element from '../../lib/element';
 import propsInit from '../../../src/lifecycle/props-init';
+import { Component } from '../../../src';
 
 describe('lifecycle/property', () => {
   function create(definition = {}, name = 'testName', value) {
@@ -21,6 +22,94 @@ describe('lifecycle/property', () => {
 
   it('should return an function', () => {
     expect(propsInit()).to.be.a('function');
+  });
+
+  describe('props declared as attributes with ES2015 classes are linked', () => {
+    it('uses the same attribute and property name for lower-case names', (done) => {
+      const elem = new (element().skate(class extends Component {
+        static get props() {
+          return { testprop: { attribute: true } };
+        }
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('testprop', 'foo'),
+        () => expect(elem.testprop).to.equal('foo'),
+        done,
+      );
+    });
+
+    it('uses the same attribute and property name for dashed-names names', (done) => {
+      const elem = new (element().skate(class extends Component {
+        static get props() {
+          return { ['test-prop']: { attribute: true } };
+        }
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('test-prop', 'foo'),
+        () => expect(elem['test-prop']).to.equal('foo'),
+        done,
+      );
+    });
+
+    it('uses a dash-cased attribute name for camel-case property names', (done) => {
+      const elem = new (element().skate(class extends Component {
+        static get props() {
+          return { testProp: { attribute: true } };
+        }
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('test-prop', 'foo'),
+        () => expect(elem.testProp).to.equal('foo'),
+        done,
+      );
+    });
+  });
+
+  describe('props declared as attributes with object are linked', () => {
+    it('uses the same attribute and property name for lower-case names', (done) => {
+      const elem = new (element().skate({
+        props: {
+          testprop: { attribute: true },
+        },
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('testprop', 'foo'),
+        () => expect(elem.testprop).to.equal('foo'),
+        done,
+      );
+    });
+
+    it('uses the same attribute and property name for dashed-names names', (done) => {
+      const elem = new (element().skate({
+        props: {
+          ['test-prop']: { attribute: true },
+        },
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('test-prop', 'foo'),
+        () => expect(elem['test-prop']).to.equal('foo'),
+        done,
+      );
+    });
+
+    it('uses a dash-cased attribute name for camel-case property names', (done) => {
+      const elem = new (element().skate({
+        props: {
+          testProp: { attribute: true },
+        },
+      }));
+
+      afterMutations(
+        () => elem.setAttribute('test-prop', 'foo'),
+        () => expect(elem.testProp).to.equal('foo'),
+        done,
+      );
+    });
   });
 
   it('should not leak options to other definitions', () => {
@@ -93,17 +182,6 @@ describe('lifecycle/property', () => {
 
   describe('api', () => {
     describe('attribute', () => {
-      it('when true, links an attribute of the name (dash-cased)', () => {
-        const elem = create({ attribute: true }, 'testName', 'something');
-
-        expect(elem.testName).to.equal('something');
-        expect(elem.getAttribute('test-name')).to.equal('something');
-
-        elem.testName = 'something else';
-        expect(elem.testName).to.equal('something else');
-        expect(elem.getAttribute('test-name')).to.equal('something else');
-      });
-
       it('setting the attribute updates the property value', done => {
         const elem = create({ attribute: true }, 'testName', 'something');
 


### PR DESCRIPTION
This fixes the test CI by skipping a few tests in IE9 and 10.