### PR TITLE
Fixes #813 V1 component constructor

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -10,6 +10,8 @@ import data from '../util/data';
 import debounce from '../util/debounce';
 import getOwnPropertyDescriptors from '../util/get-own-property-descriptors';
 
+const setElementAsDefined = elem => elem.setAttribute('defined', '');
+
 function callConstructor(elem) {
   const elemData = data(elem);
   const readyCallbacks = elemData.readyCallbacks;
@@ -30,8 +32,6 @@ function callConstructor(elem) {
   if (created) {
     created(elem);
   }
-
-  elem.setAttribute('defined', '');
 
   if (readyCallbacks) {
     readyCallbacks.forEach(cb => cb(elem));
@@ -74,7 +74,9 @@ function callDisconnected(elem) {
 
 // v1
 function Component(...args) {
-  return Reflect.construct(HTMLElement, args, this.constructor);
+  const elm = Reflect.construct(HTMLElement, args, this.constructor);
+  callConstructor(elm);
+  return elm;
 }
 
 // v1
@@ -133,7 +135,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
   connectedCallback: {
     configurable: true,
     value() {
-      callConstructor(this);
+      setElementAsDefined(this);
       callConnected(this);
     },
   },
@@ -185,6 +187,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
   createdCallback: {
     configurable: true,
     value() {
+      setElementAsDefined(this);
       callConstructor(this);
     },
   },

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -73,10 +73,8 @@ function callDisconnected(elem) {
 }
 
 // v1
-function Component(self) {
-  const elem = HTMLElement.call(this, self);
-  callConstructor(elem);
-  return elem;
+function Component(...args) {
+  return Reflect.construct(HTMLElement, args, this.constructor);
 }
 
 // v1
@@ -135,6 +133,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
   connectedCallback: {
     configurable: true,
     value() {
+      callConstructor(this);
       callConnected(this);
     },
   },

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -4,11 +4,14 @@ import assign from '../../../src/util/assign';
 import element from '../../lib/element';
 
 function create(propLocal) {
-  return new (element().skate({
+  const el = new (element().skate({
     props: {
       test: assign({ attribute: true }, propLocal),
     },
   }));
+
+  document.body.appendChild(el);
+  return el;
 }
 
 function testTypeValues(type, values) {
@@ -27,6 +30,8 @@ describe('api/prop', () => {
     beforeEach(() => {
       elem = create(prop.array());
     });
+
+    afterEach(() => elem.remove());
 
     it('default', () => {
       expect(elem.test).to.be.an('array');

--- a/test/unit/lifecycle/defined.js
+++ b/test/unit/lifecycle/defined.js
@@ -5,12 +5,16 @@ describe('lifecycle/defined', () => {
     expect(document.createElement('some-undefined-element').hasAttribute('defined')).to.equal(false);
   });
 
-  it('should add the [defined] attribute when the element is upgraded', () => {
+  it('should add the [defined] attribute when the element is upgraded', done => {
     const Elem = define('x-test', {});
     const elem = new Elem();
 
     document.body.appendChild(elem);
-    expect(elem.hasAttribute('defined')).to.equal(true);
-    elem.remove();
+
+    setTimeout(() => {
+      expect(elem.hasAttribute('defined')).to.equal(true);
+      elem.remove();
+      done();
+    }, 0);
   });
 });

--- a/test/unit/lifecycle/defined.js
+++ b/test/unit/lifecycle/defined.js
@@ -8,6 +8,9 @@ describe('lifecycle/defined', () => {
   it('should add the [defined] attribute when the element is upgraded', () => {
     const Elem = define('x-test', {});
     const elem = new Elem();
+
+    document.body.appendChild(elem);
     expect(elem.hasAttribute('defined')).to.equal(true);
+    elem.remove();
   });
 });


### PR DESCRIPTION
This uses `Reflect.constructor` in order to make the inheritance of `HTMLElement` work properly in V1. 

Also we had to move some attr initialisation to the attach callback in order to avoid DOM exceptions, more info here https://www.w3.org/TR/custom-elements/#custom-element-conformance