### PR TITLE
Fix multiple symbol props

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -163,7 +163,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
       }
 
       if (propertyName) {
-        const propData = data(this, `api/property/${propertyName}`);
+        const propData = data(this, 'props')[propertyName];
 
         // This ensures a property set doesn't cause the attribute changed
         // handler to run again once we set this flag. This only ever has a

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -16,8 +16,8 @@ function getInitialValue(elem, name, opts) {
 }
 
 function getPropData(elem, name) {
-  const namespace = typeof name === 'symbol' ? name : `api/property/${name}`;
-  return data(elem, namespace);
+  const elemData = data(elem, 'props');
+  return elemData[name] || (elemData[name] = {});
 }
 
 function createNativePropertyDefinition(name, opts) {

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -8,12 +8,8 @@ import empty from '../util/empty';
 import dashCase from '../util/dash-case';
 import getDefaultValue from '../util/get-default-value';
 import getInitialValue from '../util/get-initial-value';
+import getPropData from '../util/get-prop-data';
 import syncPropToAttr from '../util/sync-prop-to-attr';
-
-function getPropData(elem, name) {
-  const elemData = data(elem, 'props');
-  return elemData[name] || (elemData[name] = {});
-}
 
 function createNativePropertyDefinition(name, opts) {
   const prop = {

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -16,7 +16,7 @@ function getInitialValue(elem, name, opts) {
 }
 
 function getPropData(elem, name) {
-  const namespace = `api/property/${typeof name === 'symbol' ? String(name) : name}`;
+  const namespace = typeof name === 'symbol' ? name : `api/property/${name}`;
   return data(elem, namespace);
 }
 

--- a/src/util/get-prop-data.js
+++ b/src/util/get-prop-data.js
@@ -1,0 +1,6 @@
+import data from './data';
+
+export default function getPropData(elem, name) {
+  const elemData = data(elem, 'props');
+  return elemData[name] || (elemData[name] = {});
+}

--- a/src/util/sync-prop-to-attr.js
+++ b/src/util/sync-prop-to-attr.js
@@ -2,11 +2,7 @@ import data from './data';
 import empty from './empty';
 import getDefaultValue from '../util/get-default-value';
 import getInitialValue from './get-initial-value';
-
-function getPropData(elem, name) {
-  const namespace = `api/property/${typeof name === 'symbol' ? String(name) : name}`;
-  return data(elem, namespace);
-}
+import getPropData from './get-prop-data';
 
 function syncFirstTimeProp(elem, prop, propName, attributeName, propData) {
   let syncAttrValue = propData.lastAssignedValue;

--- a/test/lib/has-symbol.js
+++ b/test/lib/has-symbol.js
@@ -1,0 +1,4 @@
+// Determine if Symbols are supported.
+export function hasSymbol() {
+  return typeof Symbol === 'function'
+};

--- a/test/unit/api/props-with-symbol.js
+++ b/test/unit/api/props-with-symbol.js
@@ -1,22 +1,27 @@
 import afterMutations from '../../lib/after-mutations';
+import hasSymbol from '../../lib/after-mutations';
+import createSymbol from '../../../src/util/create-symbol';
 import element from '../../lib/element';
 import fixture from '../../lib/fixture';
 import { props } from '../../../src/index';
 
-describe('api/props', () => {
+describe('api/props-with-symbol', () => {
+  if (!hasSymbol()) {
+    return;
+  }
+
   let elem;
+  const secret = createSymbol('secret');
+  const secret2 = createSymbol('secret');
 
   beforeEach(done => {
     elem = new (element().skate({
       props: {
-        prop1: {
-          initial: 'test1',
+        [secret]: {
+          initial: 'secretKey',
         },
-        prop2: {
-          initial: 'test2',
-        },
-        prop3: {
-          default: undefined,
+        [secret2]: {
+          initial: 'secretKey2',
         },
       },
       created(el) {
@@ -34,9 +39,11 @@ describe('api/props', () => {
     it('should return only properties defined as props', () => {
       const curr = props(elem);
 
-      expect(curr.prop1).to.equal('test1');
-      expect(curr.prop2).to.equal('test2');
-      expect('prop3' in curr).to.equal(true);
+      expect(curr[secret]).to.equal('secretKey');
+      expect(curr[secret2]).to.equal('secretKey2');
+
+      expect(secret in curr).to.equal(true);
+      expect(secret2 in curr).to.equal(true);
       expect(curr.undeclaredProp).to.equal(undefined);
     });
   });
@@ -44,18 +51,16 @@ describe('api/props', () => {
   describe('setting', () => {
     it('should set all properties', () => {
       props(elem, {
-        prop1: 'updated1',
-        prop2: 'updated2',
-        undeclaredProp: 'updated3',
+        [secret]: 'newSecretKey',
+        [secret2]: 'newSecretKey2',
       });
-      expect(elem.prop1).to.equal('updated1');
-      expect(elem.prop2).to.equal('updated2');
-      expect(elem.undeclaredProp).to.equal('updated3');
+      expect(elem[secret]).to.equal('newSecretKey');
+      expect(elem[secret2]).to.equal('newSecretKey2');
     });
 
     it('should synchronously render if declared properties are set', () => {
       expect(elem._rendered).to.equal(1);
-      props(elem, { prop1: 'updated1' });
+      props(elem, { [secret]: 'updated1' });
       expect(elem._rendered).to.equal(2);
     });
 

--- a/test/unit/api/props.js
+++ b/test/unit/api/props.js
@@ -7,6 +7,7 @@ import { props } from '../../../src/index';
 describe('api/props', () => {
   let elem;
   const secret = createSymbol('secret');
+  const secret2 = createSymbol('secret');
 
   beforeEach(done => {
     elem = new (element().skate({
@@ -22,6 +23,9 @@ describe('api/props', () => {
         },
         [secret]: {
           initial: 'secretKey',
+        },
+        [secret2]: {
+          initial: 'secretKey2',
         },
       },
       created(el) {
@@ -42,7 +46,10 @@ describe('api/props', () => {
       expect(curr.prop1).to.equal('test1');
       expect(curr.prop2).to.equal('test2');
       expect(curr[secret]).to.equal('secretKey');
+      expect(curr[secret2]).to.equal('secretKey2');
+
       expect(secret in curr).to.equal(true);
+      expect(secret2 in curr).to.equal(true);
       expect('prop3' in curr).to.equal(true);
       expect(curr.undeclaredProp).to.equal(undefined);
     });
@@ -55,11 +62,13 @@ describe('api/props', () => {
         prop2: 'updated2',
         undeclaredProp: 'updated3',
         [secret]: 'newSecretKey',
+        [secret2]: 'newSecretKey2',
       });
       expect(elem.prop1).to.equal('updated1');
       expect(elem.prop2).to.equal('updated2');
       expect(elem.undeclaredProp).to.equal('updated3');
       expect(elem[secret]).to.equal('newSecretKey');
+      expect(elem[secret2]).to.equal('newSecretKey2');
     });
 
     it('should synchronously render if declared properties are set', () => {


### PR DESCRIPTION
Use the prop names as keys instead of prefixing with a string, so that skate can differentiate between multiple symbol props. Previously, using two Symbols with the same descriptor would generate something like:

```
{ 
  'api/property/Symbol()': { ... }
}
```

since we were just converting the Symbol to a string.

Also, put the props inside an object with key `props` to prevent clashing with any other skate data.