### PR TITLE
Use microtasks for debounce scheduling if available, resolves #846.

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -68,7 +68,7 @@ function syncPropsToAttrs(elem) {
 function callConnected(elem) {
   const Ctor = elem.constructor;
   const { attached } = Ctor;
-  const render = Ctor[$renderer];
+  const render = elem[$rendererDebounced];
 
   syncPropsToAttrs(elem);
 

--- a/src/api/props.js
+++ b/src/api/props.js
@@ -13,7 +13,7 @@ function get(elem) {
 
 function set(elem, newProps) {
   assign(elem, newProps);
-  if (elem.constructor.render) {
+  if (elem.constructor[$renderer]) {
     elem.constructor[$renderer](elem);
   }
 }

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -7,15 +7,40 @@ for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {
   }
 }
 
-export default function (fn) {
+function microTaskDebounce(cbFunc) {
+  let called = false;
+  let i = 0;
+  let cbArgs = [];
+  const elem = document.createElement('span');
+  const observer = new MutationObserver(() => {
+    cbFunc(...cbArgs);
+    called = false;
+    cbArgs = null;
+  });
+
+  observer.observe(elem, { childList: true });
+
+  return (...args) => {
+    cbArgs = args;
+    if (!called) {
+      called = true;
+      elem.textContent = `${i}`;
+      i += 1;
+    }
+  };
+}
+
+function taskDebounce(fn) {
   let called = false;
   return (...args) => {
     if (!called) {
       called = true;
       setTimeout(() => {
         called = false;
-        fn.apply(this, args);
+        fn(...args);
       }, timeoutDuration);
     }
   };
 }
+
+export default MutationObserver ? microTaskDebounce : taskDebounce;

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -43,4 +43,4 @@ function taskDebounce(fn) {
   };
 }
 
-export default MutationObserver ? microTaskDebounce : taskDebounce;
+export default window.MutationObserver ? microTaskDebounce : taskDebounce;

--- a/test/unit/api/props.js
+++ b/test/unit/api/props.js
@@ -59,10 +59,25 @@ describe('api/props', () => {
       expect(elem._rendered).to.equal(2);
     });
 
+    it('should synchronously render once when multiple props are set', () => {
+      expect(elem._rendered).to.equal(1);
+      props(elem, {
+        prop1: 'updated1',
+        prop2: 'updated2'
+      });
+      expect(elem._rendered).to.equal(2);
+    });
+
     it('should not render if undeclared properties are set', () => {
       expect(elem._rendered).to.equal(1);
       props(elem, { undeclaredProp: 'updated3' });
       expect(elem._rendered).to.equal(1);
     });
+
+    it('should succeed on an uninitialised element', () => {
+      const elem = element().create();
+      props(elem, { undeclaredProp: 'foo' });
+      expect(elem).property('undeclaredProp', 'foo');
+    })
   });
 });

--- a/test/unit/api/props.js
+++ b/test/unit/api/props.js
@@ -27,7 +27,10 @@ describe('api/props', () => {
       },
     }));
     fixture(elem);
-    afterMutations(done);
+    afterMutations(
+      () => {}, // .render()
+      done
+    );
   });
 
   describe('getting', () => {

--- a/test/unit/lifecycle/render.js
+++ b/test/unit/lifecycle/render.js
@@ -184,17 +184,18 @@ describe('lifecycle/render', () => {
           test: {},
         },
         updated(el) {
+          // In this test case `updated()` is *only called once* during a debounced
+          // rendering of the element (triggered when it was connected to the DOM).
+
           ++calledUpdated;
 
-          // Sync render.
+          // An internal guard should prevent this from re-rendering.
           props(el, { test: 'updated 1' });
 
-          // This will queue a render, but we should only queue if it's not in
-          // the process of rendering.
+          // An internal guard should prevent this from re-rendering.
           el.test = 'updated 2';
 
-          // Finally render. We do this sync here to make sure any prop sets
-          // don't call the debounced render.
+          // Allow the render to actually proceed.
           return true;
         },
         render() {
@@ -205,9 +206,8 @@ describe('lifecycle/render', () => {
       const elemLocal = new Elem();
       fixture(elemLocal);
       afterMutations(() => {
-        const expectedCallCount = isPolyfilled ? 2 : 1;
-        expect(calledUpdated).to.equal(expectedCallCount, 'before');
-        expect(calledRender).to.equal(expectedCallCount, 'render');
+        expect(calledUpdated).to.equal(1, 'before');
+        expect(calledRender).to.equal(1, 'render');
         done();
       });
     });

--- a/test/unit/lifecycle/render.js
+++ b/test/unit/lifecycle/render.js
@@ -14,6 +14,7 @@ describe('lifecycle/render', () => {
     });
     fixture(new Elem());
     afterMutations(
+      () => {}, // .render()
       () => expect(called).to.equal(true),
       done
     );
@@ -74,6 +75,7 @@ describe('lifecycle/render', () => {
       });
       fixture(new Elem());
       afterMutations(
+        () => {}, // .render()
         () => expect(spy.callCount).to.equal(1),
         done
       );
@@ -87,6 +89,7 @@ describe('lifecycle/render', () => {
       });
       fixture(new Elem());
       afterMutations(
+        () => {}, // .render()
         () => expect(spy.callCount).to.equal(2),
         done
       );
@@ -119,6 +122,7 @@ describe('lifecycle/render', () => {
       const elemLocal = new Elem();
       fixture(elemLocal);
       afterMutations(
+        () => {}, // .render()
         () => expect(called).to.equal(1),
         () => expect(elemLocal.test).to.equal(0),
         () => {
@@ -148,11 +152,14 @@ describe('lifecycle/render', () => {
       });
       const elemLocal = new Elem();
       fixture(elemLocal);
-      afterMutations(() => {
-        expect(calledUpdated).to.equal(true);
-        expect(calledRender).to.equal(false);
-        done();
-      });
+      afterMutations(
+        () => {}, // .render()
+        () => {
+          expect(calledUpdated).to.equal(true);
+          expect(calledRender).to.equal(false);
+        },
+        done
+      );
     });
 
     it('should allow rendering', (done) => {
@@ -169,11 +176,14 @@ describe('lifecycle/render', () => {
       });
       const elemLocal = new Elem();
       fixture(elemLocal);
-      afterMutations(() => {
-        expect(calledUpdated).to.equal(true);
-        expect(calledRender).to.equal(true);
-        done();
-      });
+      afterMutations(
+        () => {}, // .render()
+        () => {
+          expect(calledUpdated).to.equal(true);
+          expect(calledRender).to.equal(true);
+        },
+        done
+      );
     });
 
     it('should allow props to be set within it and not be called again as a result', (done) => {
@@ -205,11 +215,14 @@ describe('lifecycle/render', () => {
       });
       const elemLocal = new Elem();
       fixture(elemLocal);
-      afterMutations(() => {
-        expect(calledUpdated).to.equal(1, 'before');
-        expect(calledRender).to.equal(1, 'render');
-        done();
-      });
+      afterMutations(
+        () => {}, // .render()
+        () => {
+          expect(calledUpdated).to.equal(1, 'before');
+          expect(calledRender).to.equal(1, 'render');
+        },
+        done
+      );
     });
   });
 
@@ -231,12 +244,15 @@ describe('lifecycle/render', () => {
       });
       const elemLocal = new Elem();
       fixture(elemLocal);
-      afterMutations(() => {
-        expect(order[0]).to.equal('updated');
-        expect(order[1]).to.equal('render');
-        expect(order[2]).to.equal('rendered');
-        done();
-      });
+      afterMutations(
+        () => {}, // .render()
+        () => {
+          expect(order[0]).to.equal('updated');
+          expect(order[1]).to.equal('render');
+          expect(order[2]).to.equal('rendered');
+        },
+        done
+      );
     });
 
     it('should not be called if render() is not defined', (done) => {

--- a/test/unit/vdom/elements.js
+++ b/test/unit/vdom/elements.js
@@ -22,6 +22,7 @@ describe('vdom/elements', () => {
       it('(tagName)', (done) => {
         const elem = create(() => vdom.element('div'));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           done
         );
@@ -31,6 +32,7 @@ describe('vdom/elements', () => {
         const Ctor = ctor('div');
         const elem = create(() => vdom.element(Ctor));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           done
         );
@@ -39,6 +41,7 @@ describe('vdom/elements', () => {
       it('(tagName, textContent)', (done) => {
         const elem = create(() => vdom.element('div', 'text'));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
           done
@@ -48,6 +51,7 @@ describe('vdom/elements', () => {
       it('(tagName, childrenFunction)', (done) => {
         const elem = create(() => vdom.element('div', vdom.text.bind(null, 'text')));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
           done
@@ -58,6 +62,7 @@ describe('vdom/elements', () => {
         const Ctor = ctor('div');
         const elem = create(() => vdom.element(Ctor, 'text'));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
           done
@@ -68,6 +73,7 @@ describe('vdom/elements', () => {
         const Ctor = ctor('div');
         const elem = create(() => vdom.element(Ctor, vdom.text.bind(null, 'text')));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
           done
@@ -77,6 +83,7 @@ describe('vdom/elements', () => {
       it('tagName, attrsObject, textContent', (done) => {
         const elem = create(() => vdom.element('div', { id: 'test' }, 'text'));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
@@ -87,6 +94,7 @@ describe('vdom/elements', () => {
       it('tagName, attrsObject, childrenFunction', (done) => {
         const elem = create(() => vdom.element('div', { id: 'test' }, vdom.text.bind(null, 'text')));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
@@ -98,6 +106,7 @@ describe('vdom/elements', () => {
         const Ctor = ctor('div');
         const elem = create(() => vdom.element(Ctor, { id: 'test' }, 'text'));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
@@ -109,6 +118,7 @@ describe('vdom/elements', () => {
         const Ctor = ctor('div');
         const elem = create(() => vdom.element(Ctor, { id: 'test' }, vdom.text.bind(null, 'text')));
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
           () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
           () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
@@ -139,30 +149,32 @@ describe('vdom/elements', () => {
     fixture().appendChild(elem1);
     fixture().appendChild(elem2);
 
-    afterMutations(() => {
-      const ch1 = elem1[symbols.shadowRoot].firstElementChild;
-      const ch2 = elem2[symbols.shadowRoot].firstElementChild;
+    afterMutations(
+      () => {}, // .render()
+      () => {
+        const ch1 = elem1[symbols.shadowRoot].firstElementChild;
+        const ch2 = elem2[symbols.shadowRoot].firstElementChild;
 
-      function assertSlotElement() {
-        expect(ch1.tagName).to.equal('SLOT', 'vdom');
-        expect(ch1.getAttribute('name')).to.equal('test', 'vdom');
-        expect(ch2.tagName).to.equal('SLOT', 'vdom.element(slot)');
-        expect(ch2.getAttribute('name')).to.equal('test', 'vdom.element(slot)');
-      }
+        function assertSlotElement() {
+          expect(ch1.tagName).to.equal('SLOT', 'vdom');
+          expect(ch1.getAttribute('name')).to.equal('test', 'vdom');
+          expect(ch2.tagName).to.equal('SLOT', 'vdom.element(slot)');
+          expect(ch2.getAttribute('name')).to.equal('test', 'vdom.element(slot)');
+        }
 
-      if (shadowDomV1) {
-        assertSlotElement();
-      } else if (shadowDomV0) {
-        expect(ch1.tagName).to.equal('CONTENT', 'vdom');
-        expect(ch1.getAttribute('select')).to.equal('[slot="test"]', 'vdom');
-        expect(ch2.tagName).to.equal('CONTENT', 'vdom.element(slot)');
-        expect(ch2.getAttribute('select')).to.equal('[slot="test"]', 'vdom.element(slot)');
-      } else {
-        assertSlotElement();
-      }
-
-      done();
-    });
+        if (shadowDomV1) {
+          assertSlotElement();
+        } else if (shadowDomV0) {
+          expect(ch1.tagName).to.equal('CONTENT', 'vdom');
+          expect(ch1.getAttribute('select')).to.equal('[slot="test"]', 'vdom');
+          expect(ch2.tagName).to.equal('CONTENT', 'vdom.element(slot)');
+          expect(ch2.getAttribute('select')).to.equal('[slot="test"]', 'vdom.element(slot)');
+        } else {
+          assertSlotElement();
+        }
+      },
+      done
+    );
   });
 
   it('passing a component constructor to the vdom.element() function', (done) => {
@@ -185,6 +197,7 @@ describe('vdom/elements', () => {
 
     fixture().appendChild(elem1);
     afterMutations(
+      () => {}, // .render()
       () => expect(elem2[symbols.shadowRoot].textContent).to.equal('rendered'),
       done
     );
@@ -205,6 +218,7 @@ describe('vdom/elements', () => {
 
         fixture().appendChild(elem);
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
@@ -222,6 +236,7 @@ describe('vdom/elements', () => {
 
         fixture().appendChild(elem);
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
@@ -239,6 +254,7 @@ describe('vdom/elements', () => {
 
         fixture().appendChild(elem);
         afterMutations(
+          () => {}, // .render()
           () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
@@ -259,6 +275,7 @@ describe('vdom/elements', () => {
 
       fixture().appendChild(elem);
       afterMutations(
+        () => {}, // .render()
         () => expect(elem[symbols.shadowRoot].innerHTML).to.equal('<ul><li><a>Item 1</a></li><li><a>Item 2</a></li></ul>'),
         done
       );
@@ -283,6 +300,7 @@ describe('vdom/elements', () => {
 
       fixture().appendChild(elem);
       afterMutations(
+        () => {}, // .render()
         () => expect(elem[symbols.shadowRoot].innerHTML).to.equal('<div></div>'),
         () => {
           const div = elem[symbols.shadowRoot];

--- a/test/unit/vdom/events.js
+++ b/test/unit/vdom/events.js
@@ -26,32 +26,34 @@ describe('vdom/events (on*)', () => {
     const el = new MyEl();
     fixture(el);
 
-    afterMutations(() => {
-      const shadowDiv = el[symbols.shadowRoot].children[0];
+    afterMutations(
+      () => {}, // .render()
+      () => {
+        const shadowDiv = el[symbols.shadowRoot].children[0];
 
-      // Ensures that it rendered.
-      expect(shadowDiv.textContent).to.equal('0');
-      expect(el._test).to.equal(0);
+        // Ensures that it rendered.
+        expect(shadowDiv.textContent).to.equal('0');
+        expect(el._test).to.equal(0);
 
-      // Trigger the handler.
-      emit(shadowDiv, 'event');
+        // Trigger the handler.
+        emit(shadowDiv, 'event');
 
-      // Ensure the event fired.
-      expect(el._test).to.equal(1);
+        // Ensure the event fired.
+        expect(el._test).to.equal(1);
 
-      // Re-render.
-      props(el, { test: el.test + 1 });
-      expect(shadowDiv.textContent).to.equal('1');
-      emit(shadowDiv, 'event');
-      expect(el._test).to.equal(2);
+        // Re-render.
+        props(el, { test: el.test + 1 });
+        expect(shadowDiv.textContent).to.equal('1');
+        emit(shadowDiv, 'event');
+        expect(el._test).to.equal(2);
 
-      props(el, { test: el.test + 1 });
-      expect(shadowDiv.textContent).to.equal('2');
-      emit(shadowDiv, 'event');
-      expect(el._test).to.equal(3);
-
-      done();
-    });
+        props(el, { test: el.test + 1 });
+        expect(shadowDiv.textContent).to.equal('2');
+        emit(shadowDiv, 'event');
+        expect(el._test).to.equal(3);
+      },
+      done
+    );
   });
 
   it('should trigger events bubbled from descendants', done => {
@@ -66,11 +68,14 @@ describe('vdom/events (on*)', () => {
     }));
     fixture().appendChild(myel);
 
-    afterMutations(() => {
-      emit(myel[symbols.shadowRoot].querySelector('span'), 'test');
-      expect(called).to.equal(true);
-      done();
-    });
+    afterMutations(
+      () => {}, // .render()
+      () => {
+        emit(myel[symbols.shadowRoot].querySelector('span'), 'test');
+        expect(called).to.equal(true);
+      },
+      done
+    );
   });
 
   it('should emit events from shadow dom', done => {
@@ -88,12 +93,15 @@ describe('vdom/events (on*)', () => {
     myel.addEventListener('test', test);
     fixture().appendChild(myel);
 
-    afterMutations(() => {
-      emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { detail: 'detail' });
-      expect(called).to.equal(true);
-      expect(detail).to.equal('detail');
-      done();
-    });
+    afterMutations(
+      () => {}, // .render()
+      () => {
+        emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { detail: 'detail' });
+        expect(called).to.equal(true);
+        expect(detail).to.equal('detail');
+      },
+      done
+    );
   });
 
   it('should not fail for listeners that are not functions', done => {
@@ -103,10 +111,13 @@ describe('vdom/events (on*)', () => {
       },
     }));
     fixture(myel);
-    afterMutations(() => {
-      emit(myel[symbols.shadowRoot].firstChild, 'test');
-      done();
-    });
+    afterMutations(
+      () => {}, // .render()
+      () => {
+        emit(myel[symbols.shadowRoot].firstChild, 'test');
+      },
+      done
+    );
   });
 
   describe('built-in / custom', () => {
@@ -134,6 +145,7 @@ describe('vdom/events (on*)', () => {
       }));
       fixture(el);
       afterMutations(
+        () => {}, // .render()
         () => {
           div = el[symbols.shadowRoot].firstChild;
         },

--- a/test/unit/vdom/incremental-dom.js
+++ b/test/unit/vdom/incremental-dom.js
@@ -26,6 +26,8 @@ describe('IncrementalDOM', () => {
     }
 
     describe('efficient rendering', () => {
+      const skip = !window.MutationObserver;
+
       function renderCounter() {
         const { safe, skate } = element();
         let renderCount = 0;
@@ -46,7 +48,9 @@ describe('IncrementalDOM', () => {
         };
       }
 
-      it('causes only one render for new elements with no attributes before the next tick', (done) => {
+      it('causes only one render for new elements with no attributes before the next tick', function (done) {
+        if (skip) this.skip();
+
         const { tag, renderCount } = renderCounter();
 
         // Schedule the assertions prior to using incremental dom, to verify
@@ -62,7 +66,9 @@ describe('IncrementalDOM', () => {
         });
       });
 
-      it('causes only one render for new elements with multiple attributes before the next tick', (done) => {
+      it('causes only one render for new elements with multiple attributes before the next tick', function (done) {
+        if (skip) this.skip();
+
         const { tag, renderCount } = renderCounter();
 
         // Schedule the assertions prior to using incremental dom, to verify

--- a/test/unit/vdom/incremental-dom.js
+++ b/test/unit/vdom/incremental-dom.js
@@ -1,5 +1,8 @@
 import * as IncrementalDOM from 'incremental-dom';
 import { define, vdom } from '../../../src/index';
+import afterMutations from '../../lib/after-mutations';
+import element from '../../lib/element';
+import fixture from '../../lib/fixture';
 
 function testBasicApi(name) {
   describe(name, () => {
@@ -18,14 +21,66 @@ describe('IncrementalDOM', () => {
   testBasicApi('text');
 
   describe('function tag names', () => {
-    let fixture;
-    beforeEach(() => {
-      fixture = document.createElement('div');
-    });
-
     function patchIt(desc, func) {
-      it(desc, () => IncrementalDOM.patch(fixture, func));
+      it(desc, () => IncrementalDOM.patch(fixture(), func));
     }
+
+    describe('efficient rendering', () => {
+      function renderCounter() {
+        const { safe, skate } = element();
+        let renderCount = 0;
+
+        skate({
+          render() {
+            renderCount++;
+          },
+          props: {
+            foo: { attribute: true },
+            bar: { attribute: true }
+          }
+        });
+
+        return {
+          tag: safe,
+          renderCount: () => renderCount
+        };
+      }
+
+      it('causes only one render for new elements with no attributes before the next tick', (done) => {
+        const { tag, renderCount } = renderCounter();
+
+        // Schedule the assertions prior to using incremental dom, to verify
+        // the implementation isn't doing naive `setTimeout()` scheduling.
+        setTimeout(() => {
+          expect(renderCount()).to.equal(1);
+          done();
+        }, 0);
+
+        IncrementalDOM.patch(fixture(), () => {
+          vdom.elementOpen(tag);
+          vdom.elementClose(tag);
+        });
+      });
+
+      it('causes only one render for new elements with multiple attributes before the next tick', (done) => {
+        const { tag, renderCount } = renderCounter();
+
+        // Schedule the assertions prior to using incremental dom, to verify
+        // the implementation isn't doing naive `setTimeout()` scheduling.
+        setTimeout(() => {
+          const elem = fixture().querySelector(tag);
+          expect(elem.foo).to.equal('value')
+          expect(elem.bar).to.equal('value');
+          expect(renderCount()).to.equal(1);
+          done();
+        }, 0);
+
+        IncrementalDOM.patch(fixture(), () => {
+          vdom.elementOpen(tag, null, null, 'foo', 'value', 'bar', 'value');
+          vdom.elementClose(tag);
+        });
+      });
+    });
 
     describe('passing element name', () => {
       patchIt('elementOpenStart, attr, elementOpenEnd, elementClose', () => {
@@ -33,7 +88,7 @@ describe('IncrementalDOM', () => {
         vdom.attr('id', 'test');
         vdom.elementOpenEnd('div');
         vdom.elementClose('div');
-        expect(fixture.innerHTML).to.equal('<div id="test"></div>');
+        expect(fixture().innerHTML).to.equal('<div id="test"></div>');
       });
     });
 
@@ -67,8 +122,8 @@ describe('IncrementalDOM', () => {
 
     describe('passing a function helper', () => {
       function patchAssert(elem, { checkChildren = true } = {}) {
-        expect(fixture.firstChild).to.equal(elem);
-        expect(fixture.innerHTML).to.equal(`<div id="test">${checkChildren ? '<span>test</span>' : ''}</div>`);
+        expect(fixture().firstChild).to.equal(elem);
+        expect(fixture().innerHTML).to.equal(`<div id="test">${checkChildren ? '<span>test</span>' : ''}</div>`);
       }
 
       function renderChildren() {

--- a/test/unit/vdom/properties.js
+++ b/test/unit/vdom/properties.js
@@ -11,6 +11,7 @@ describe('vdom/properties', () => {
     }));
     fixture(elem);
     afterMutations(
+      () => {}, // x-test.render()
       () => expect(elem[symbols.shadowRoot].firstChild.className).to.equal('test'),
       done
     );
@@ -31,6 +32,7 @@ describe('vdom/properties', () => {
     fixture(elem);
 
     afterMutations(
+      () => {}, // x-test.render()
       () => expect(elem[symbols.shadowRoot].firstChild.getAttribute('class')).to.equal('inner'),
       done
     );
@@ -48,6 +50,7 @@ describe('vdom/properties', () => {
     fixture(elem);
     let div;
     afterMutations(
+      () => {}, // x-test.render()
       () => (div = elem[symbols.shadowRoot].firstChild),
       () => (elem.test = true),
       () => expect(div.hasAttribute('test')).to.equal(true),
@@ -100,6 +103,9 @@ describe('vdom/properties', () => {
       const elem = new Elem1();
       fixture(elem);
       afterMutations(
+        () => {}, // Elem1.render()
+        () => {}, // Elem2.render()
+        () => {}, // ...
         () => expect(text(elem)).to.equal('closed', 'init'),
         () => props(elem, { open: true }),
         () => expect(text(elem)).to.equal('open', 'false -> true'),

--- a/test/unit/vdom/ref.js
+++ b/test/unit/vdom/ref.js
@@ -49,6 +49,7 @@ function test(name, el) {
       // We change elem.num here so that we can see what happens when we
       // re-render without changing the ref.
       afterMutations(
+        () => {}, // x-test.render()
         () => expect(num).to.equal(1),
         () => props(elem, { num: elem.num + 1 }),
         () => expect(num).to.equal(1),
@@ -61,12 +62,15 @@ function test(name, el) {
     it('should not call a removed ref', done => {
       let num = 0;
       const elem = create(() => ++num);
-      afterMutations(() => {
-        expect(num).to.equal(1);
-        props(elem, { ref: null });
-        expect(num).to.equal(1);
-        done();
-      });
+      afterMutations(
+        () => {}, // x-test.render()
+        () => {
+          expect(num).to.equal(1);
+          props(elem, { ref: null });
+          expect(num).to.equal(1);
+          done();
+        }
+      );
     });
   });
 }

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -63,6 +63,7 @@ describe('vdom/skip', () => {
       '<div></div>11 <div>12 <void></void><span>13 </span><div>14 <span>15</span></div></div>';
     fixture(elem);
     afterMutations(
+      () => {}, // x-test.render()
       () => expect(sr(elem).innerHTML).to.equal(html),
       () => expect(sr(elem).querySelectorAll('void').length).to.equal(2),
       () => props(elem, { num: elem.num + 1 }),
@@ -97,6 +98,7 @@ describe('vdom/skip', () => {
     const elem = new Elem();
     fixture(elem);
     afterMutations(
+      () => {}, // x-test.render()
       () => expect(elem[symbols.shadowRoot].textContent).to.equal('222'),
       () => props(elem, { num: elem.num + 1 }),
       () => expect(elem[symbols.shadowRoot].textContent).to.equal('222'),
@@ -123,6 +125,7 @@ describe('vdom/skip', () => {
     const elem = new Elem();
     fixture(elem);
     afterMutations(
+      () => {}, // x-test.render()
       () => (elem[symbols.shadowRoot].firstElementChild.textContent = 'testing'),
       () => props(elem, { test: 0 }),
       () => expect(elem[symbols.shadowRoot].firstElementChild.textContent).to.equal('testing'),
@@ -142,6 +145,7 @@ describe('vdom/skip', () => {
     const elem = new Elem();
     fixture(elem);
     afterMutations(
+      () => {}, // x-test.render()
       () => (elem[symbols.shadowRoot].firstElementChild.textContent = 'testing'),
       () => props(elem, { test: 0 }),
       () => expect(elem[symbols.shadowRoot].firstElementChild.textContent).to.equal('testing'),


### PR DESCRIPTION
Copying across @zzarcon's [concern](https://github.com/skatejs/skatejs/pull/850#issuecomment-252840327):

> This approach seems quite good to me, the only thing Im wondering its if we should disconnect the `MutationObserver` observer when the component gets disconnected? 

> Not sure if right now we will leak something, or maybe we just don't need to care about it.