### PR TITLE
chore: Remove pre-commit hooks and cleanup unnecessary npm scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint": "3.6.1",
     "eslint-friendly-formatter": "^2.0.6",
     "eslint-plugin-import": "^2.0.1",
-    "precommit-hook": "^3.0.0",
     "react": "15.x",
     "react-dom": "15.3.2",
     "skatejs-build": "8.1.2",
@@ -40,17 +39,11 @@
   },
   "scripts": {
     "test": "sk-tests",
-    "test-watch": "sk-tests-watch",
-    "test-perf": "sk-tests-perf",
-    "precommit": "sk-lint && npm ls && npm test",
     "prepublish": "sk-bundle"
   },
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  },
-  "pre-commit": [
-    "precommit"
-  ]
+  }
 }


### PR DESCRIPTION
The pre-commit hook failed every single commit even if re-npm installing. It also adds jshint files and unnecessarily modifies the package.json on every fresh install.

This will make its way back in to skatejs-build in another form.