### PR TITLE
Allow components to extend other Elements than HTMLElement

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -320,4 +320,8 @@ Component.prototype = Object.create(HTMLElement.prototype, {
   }
 });
 
+export const component = (superClass = HTMLElement) => {
+  return Component.extend({}, superClass);
+};
+
 export default Component;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import * as prop from './api/prop';
 import * as symbols from './api/symbols';
 import * as vdom from './api/vdom';
 import Component from './api/component';
+import { component } from './api/component';
 import define from './api/define';
 import emit from './api/emit';
 import link from './api/link';
@@ -12,6 +13,7 @@ const h = vdom.builder();
 
 export {
   Component,
+  component,
   define,
   emit,
   h,

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -1,7 +1,8 @@
 /* eslint-env jasmine, mocha */
 
-import { define } from '../../src/index';
+import { define } from '../../src';
 import helperElement from '../lib/element';
+import { component } from '../../src';
 
 const { HTMLElement } = window;
 
@@ -28,6 +29,14 @@ describe('Returning a constructor', () => {
 
     expect(element.func1).to.equal(Element.prototype.func1);
     expect(element.func2).to.equal(Element.prototype.func2);
+  });
+
+  it('should be able to extend other elements when passed as parameter', () => {
+    const tag = helperElement('my-el');
+    const Element = define(tag.safe, class extends component(HTMLInputElement) {});
+    const element = new Element();
+
+    expect(element).to.be.an.instanceof(HTMLInputElement);
   });
 
   it('should not allow the constructor property to be enumerated.', () => {


### PR DESCRIPTION
As @treshugart suggested, now we can extend other components than `HTMLElement`: 

Extending `HTMLInputElement` 
```javascript
define('my-element', class extends component(HTMLInputElement) {});
````

Default extend to `HTMLElement`
```javascript
define('my-element', class extends component() {});
```

We will need to add some docs in order to explain users how to use this, thoughts? @bradleyayers @treshugart 

Closes #804