### PR TITLE
#710 - remove support for v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ const skate = window.skate;
 
 ## Dependencies
 
-Skate doesn't require you provide any external dependencies, but recommends you provide some web component polyfills depending on what browsers you require support for.
+Skate doesn't require you provide any external dependencies, but recommends you provide some web component polyfills depending on what browsers you require support for. **Skate requires both Custom Elements and Shadow DOM v1.**
 
 To get up and running quickly with our recommended configuration, we've created a single package called [`skatejs-web-components`](https://github.com/skatejs/web-components) where all you have to do is load it before Skate.
 
@@ -215,8 +215,6 @@ Or you can use script tags:
 ```
 
 If you want finer grained control about which polyfills you use, you'll have to BYO Custom Element and Shadow DOM polyfills.
-
-*Skate will work without Shadow DOM support, but you won't be able to compose components together due to the lack of DOM encapsulation that Shadow DOM gives you.*
 
 
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ Or you can use script tags:
 <script src="https://unpkg.com/skatejs/dist/index-with-deps.min.js"></script>
 ```
 
-If you want finer grained control about which polyfills you use, you'll have to BYO Custom Element and Shadow DOM V1 polyfills. Skate will work without Shadow DOM support, but you won't be able to compose components together due to the lack of DOM encapsulation that Shadow DOM gives you.
+If you want finer grained control about which polyfills you use, you'll have to BYO Custom Element and Shadow DOM polyfills.
 
-**Skate works with the native V0 APIs, however, the V0 polyfills have several bugs that are inconsistent with the native APIs, so it's not recommended you try and use the V0 polyfills.**
+*Skate will work without Shadow DOM support, but you won't be able to compose components together due to the lack of DOM encapsulation that Shadow DOM gives you.*
 
 
 
@@ -251,9 +251,7 @@ If you have any questions about Skate you can use one of these:
 
 Let's define some terms used in these docs:
 
-- v0 - the original Blink implementation of web components - when the spec was still contentious.
-- v1 - the non-contentious - modern-day - specs.
-- polyfill, polyfilled, polyfill-land - not v0 or v1; no native custom element support at all.
+- polyfill, polyfilled, polyfill-land - no native web component support.
 - upgrade, upgraded, upgrading - when an element is initialised as a custom element.
 
 
@@ -622,7 +620,7 @@ When the property is initialised, `oldValue` will always be `undefined` and `new
 
 #### `created`
 
-Function that is called when the element is created. This corresponds to the native `createdCallback` (v0) or `constructor` (v1). We don't use `constructor` here because Skate does a lot of automation in it and thus offers this as a way to hook into that part of the lifecycle. It is the first lifecycle callback that is called and is called after the `prototype` is set up.
+Function that is called when the element is created. This gets called during element construction. We don't use `constructor` here because Skate does a lot of automation in it and thus offers this as a way to hook into that part of the lifecycle. It is the first lifecycle callback that is called and is called after the `prototype` is set up.
 
 ```js
 skate.define('my-component', {
@@ -797,7 +795,7 @@ The only argument passed to `detached` is component element. In this case that i
 
 #### `attributeChanged`
 
-Function that is called whenever an attribute is added, updated or removed. This corresponds to the native `attributeChangedCallback` (both v0 and v1). Generally, you'll probably end up using `props` that have linked attributes instead of this callback, but there are still use cases where this could come in handy.
+Function that is called whenever an attribute is added, updated or removed. This corresponds to the native `attributeChangedCallback`. Generally, you'll probably end up using `props` that have linked attributes instead of this callback, but there are still use cases where this could come in handy.
 
 ```js
 skate.define('my-component', {
@@ -818,21 +816,11 @@ The arguments passed to the `attributeChanged()` callback differ from the native
 - `elem` is the component element
 - `data` is an object containing attribute `name`, `newValue` and `oldValue`. If `newValue` and `oldValue` are empty, the values are `undefined`.
 
-There are differences between v0 and v1 that Skate normalises to behave like v1. In v0:
-
-1. The `attributeChangedCallback()` is *not* invoked for every attribute that exists on the element at the time of upgrading.
-2. You can call `setAttribute()` at any point in the element lifecycle and it will queue a call to it.
-
-In v1:
-
-1. The `attributeChangedCallback()` *is* invoked for every attribute that exists on the element at the time of creation.
-2. Only once the constructor has been called and `attributeChangedCallback()` invoked for each existing attribute, can calls to `setAttribute()` begin to queue calls to `attributeChangedCallback()`.
-
 
 
 #### `observedAttributes`
 
-This behaves exactly like described in the [v1 spec](http://w3c.github.io/webcomponents/spec/custom/#custom-elements-autonomous-example).
+This behaves exactly like described in the [spec](http://w3c.github.io/webcomponents/spec/custom/#custom-elements-autonomous-example).
 
 For example, the following:
 

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -6,7 +6,6 @@ import {
   renderer as $renderer,
   rendererDebounced as $rendererDebounced,
   rendering as $rendering,
-  shadowRoot as $shadowRoot,
   updated as $updated
 } from '../util/symbols';
 import {
@@ -20,16 +19,6 @@ import getSetProps from './props';
 import syncPropToAttr from '../util/sync-prop-to-attr';
 
 const { HTMLElement } = window;
-
-// Uses Shadow DOM only if it's available. Once all browsers support it
-// natively then we can remove this function and call it directly.
-function attachShadow (elem) {
-  return elem.attachShadow ? elem.attachShadow({ mode: 'open' }) : elem;
-}
-
-function getOrAttachShadow (elem) {
-  return elem[$shadowRoot] || (elem[$shadowRoot] = attachShadow(elem));
-}
 
 function callConstructor (elem) {
   const elemData = data(elem);
@@ -210,7 +199,16 @@ Component[$renderer] = function _renderer (elem) {
   }
 
   if (shouldRender) {
-    this.renderer({ elem, render: this.render, shadowRoot: getOrAttachShadow(elem) });
+    if (!elem.shadowRoot) {
+      elem.attachShadow({ mode: 'open' });
+    }
+
+    this.renderer({
+      elem,
+      render: this.render,
+      shadowRoot: elem.shadowRoot
+    });
+
     if (typeof this.rendered === 'function') {
       this.rendered(elem);
     }

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -10,10 +10,7 @@ import {
   updated as $updated
 } from '../util/symbols';
 import {
-  customElementsV0,
-  reflect,
-  shadowDomV0,
-  shadowDomV1
+  reflect
 } from '../util/support';
 import data from '../util/data';
 import debounce from '../util/debounce';
@@ -28,12 +25,7 @@ const { HTMLElement } = window;
 // Once v1 is supported everywhere, we can call elem.attachShadow() directly
 // and remove this function.
 function attachShadow (elem) {
-  if (shadowDomV1) {
-    return elem.attachShadow({ mode: 'open' });
-  } else if (shadowDomV0) {
-    return elem.createShadowRoot();
-  }
-  return elem;
+  return elem.attachShadow ? elem.attachShadow({ mode: 'open' }) : elem;
 }
 
 function getOrAttachShadow (elem) {
@@ -69,18 +61,6 @@ function callConstructor (elem) {
   if (readyCallbacks) {
     readyCallbacks.forEach(cb => cb(elem));
     delete elemData.readyCallbacks;
-  }
-
-  // In v0 we must ensure the attributeChangedCallback is called for attrs
-  // that aren't linked to props so that the callback behaves the same no
-  // matter if v0 or v1 is being used.
-  if (customElementsV0) {
-    constructor.observedAttributes.forEach((name) => {
-      const propertyName = data(elem, 'attributeLinks')[name];
-      if (!propertyName) {
-        elem.attributeChangedCallback(name, null, elem.getAttribute(name));
-      }
-    });
   }
 }
 
@@ -263,11 +243,6 @@ Component.prototype = Object.create(HTMLElement.prototype, {
     value (name, oldValue, newValue) {
       const { attributeChanged, observedAttributes } = this.constructor;
       const propertyName = data(this, 'attributeLinks')[name];
-
-      // In V0 we have to ensure the attribute is being observed.
-      if (customElementsV0 && observedAttributes.indexOf(name) === -1) {
-        return;
-      }
 
       if (propertyName) {
         const propData = data(this, 'props')[propertyName];

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -8,9 +8,6 @@ import {
   rendering as $rendering,
   updated as $updated
 } from '../util/symbols';
-import {
-  reflect
-} from '../util/support';
 import data from '../util/data';
 import debounce from '../util/debounce';
 import getAllKeys from '../util/get-all-keys';
@@ -87,7 +84,7 @@ function callDisconnected (elem) {
 
 // v1
 function Component (...args) {
-  const elem = reflect
+  const elem = typeof Reflect === 'object'
     ? Reflect.construct(HTMLElement, args, this.constructor)
     : HTMLElement.call(this, args[0]);
   callConstructor(elem);

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -236,7 +236,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
     }
   },
 
-  // v0 and v1
+  // v1
   attributeChangedCallback: {
     configurable: true,
     value (name, oldValue, newValue) {
@@ -266,30 +266,6 @@ Component.prototype = Object.create(HTMLElement.prototype, {
       if (attributeChanged) {
         attributeChanged(this, { name, newValue, oldValue });
       }
-    }
-  },
-
-  // v0
-  createdCallback: {
-    configurable: true,
-    value () {
-      callConstructor(this);
-    }
-  },
-
-  // v0
-  attachedCallback: {
-    configurable: true,
-    value () {
-      callConnected(this);
-    }
-  },
-
-  // v0
-  detachedCallback: {
-    configurable: true,
-    value () {
-      callDisconnected(this);
     }
   }
 });

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -21,9 +21,8 @@ import syncPropToAttr from '../util/sync-prop-to-attr';
 
 const { HTMLElement } = window;
 
-// Abstracts shadow root across v1, v0 and no support.
-// Once v1 is supported everywhere, we can call elem.attachShadow() directly
-// and remove this function.
+// Uses Shadow DOM only if it's available. Once all browsers support it
+// natively then we can remove this function and call it directly.
 function attachShadow (elem) {
   return elem.attachShadow ? elem.attachShadow({ mode: 'open' }) : elem;
 }

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -238,7 +238,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
   attributeChangedCallback: {
     configurable: true,
     value (name, oldValue, newValue) {
-      const { attributeChanged, observedAttributes } = this.constructor;
+      const { attributeChanged } = this.constructor;
       const propertyName = data(this, 'attributeLinks')[name];
 
       if (propertyName) {

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -82,7 +82,7 @@ function callDisconnected (elem) {
   }
 }
 
-// v1
+// Custom Elements v1
 function Component (...args) {
   const elem = typeof Reflect === 'object'
     ? Reflect.construct(HTMLElement, args, this.constructor)
@@ -91,7 +91,7 @@ function Component (...args) {
   return elem;
 }
 
-// v1
+// Custom Elements v1
 Component.observedAttributes = [];
 
 // Skate
@@ -215,7 +215,7 @@ Component[$renderer] = function _renderer (elem) {
 };
 
 Component.prototype = Object.create(HTMLElement.prototype, {
-  // v1
+  // Custom Elements v1
   connectedCallback: {
     configurable: true,
     value () {
@@ -223,7 +223,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
     }
   },
 
-  // v1
+  // Custom Elements v1
   disconnectedCallback: {
     configurable: true,
     value () {
@@ -231,7 +231,7 @@ Component.prototype = Object.create(HTMLElement.prototype, {
     }
   },
 
-  // v1
+  // Custom Elements v1
   attributeChangedCallback: {
     configurable: true,
     value (name, oldValue, newValue) {

--- a/src/api/symbols.js
+++ b/src/api/symbols.js
@@ -1,1 +1,1 @@
-export { name, shadowRoot } from '../util/symbols';
+export { name } from '../util/symbols';

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -10,11 +10,9 @@ import {
   text
 } from 'incremental-dom';
 import { name as $name, ref as $ref } from '../util/symbols';
-import { shadowDomV0, shadowDomV1 } from '../util/support';
 import propContext from '../util/prop-context';
 
 const applyDefault = attributes[symbols.default];
-const fallbackToV0 = !shadowDomV1 && shadowDomV0;
 
 // A stack of children that corresponds to the current function helper being
 // executed.
@@ -67,15 +65,6 @@ const attributesContext = propContext(attributes, {
   className: applyProp,
   disabled: applyProp,
   value: applyProp,
-
-  // V0 Shadow DOM to V1 normalisation.
-  name (elem, name, value) {
-    if (elem.tagName === 'CONTENT') {
-      name = 'select';
-      value = `[slot="${value}"]`;
-    }
-    applyDefault(elem, name, value);
-  },
 
   // Ref handler.
   ref (elem, name, value) {
@@ -145,12 +134,6 @@ function resolveTagName (tname) {
   // - If a standard function, it is used as a helper.
   if (typeof tname === 'function') {
     return tname[$name] || tname;
-  }
-
-  // Skate allows the consumer to use <slot /> and it will translate it to
-  // <content /> if Shadow DOM V0 is preferred.
-  if (tname === 'slot' && fallbackToV0) {
-    return 'content';
   }
 
   // All other tag names are just passed through.

--- a/src/util/support.js
+++ b/src/util/support.js
@@ -1,10 +1,1 @@
-const { Document } = window;
-const doc = document;
-const win = window;
-const div = doc.createElement('div');
-export const customElementsV0 = !!doc.registerElement;
-export const customElementsV1 = !!win.customElements;
-export const shadowDomV0 = !!div.createShadowRoot;
-export const shadowDomV1 = !!div.attachShadow;
 export const reflect = 'Reflect' in window;
-export const isPolyfilled = !!Document.prototype.registerElement;

--- a/src/util/support.js
+++ b/src/util/support.js
@@ -1,1 +1,0 @@
-export const reflect = 'Reflect' in window;

--- a/src/util/symbols.js
+++ b/src/util/symbols.js
@@ -6,5 +6,4 @@ export const ref = '____skate_ref';
 export const renderer = '____skate_renderer';
 export const rendering = '____skate_rendering';
 export const rendererDebounced = '____skate_rendererDebounced';
-export const shadowRoot = '____skate_shadowRoot';
 export const updated = '____skate_updated';

--- a/test/boot.js
+++ b/test/boot.js
@@ -2,7 +2,7 @@
 
 import helperFixture from './lib/fixture';
 
-if (!document.registerElement && !window.customElements) {
+if (!window.customElements) {
   require('skatejs-web-components');
 }
 

--- a/test/boot.js
+++ b/test/boot.js
@@ -2,9 +2,7 @@
 
 import helperFixture from './lib/fixture';
 
-if (!window.customElements) {
-  require('skatejs-web-components');
-}
+require('skatejs-web-components');
 
 mocha.setup({ timeout: 10000 }); // eslint-disable-line no-undef
 

--- a/test/unit/api/define.js
+++ b/test/unit/api/define.js
@@ -1,16 +1,11 @@
 /* eslint-env jasmine, mocha */
 
 import { Component, define, symbols } from '../../../src/index';
-import { customElementsV0, customElementsV1 } from '../../../src/util/support';
 
 const { name: $name } = symbols;
 
 function mockDefine (name) {
-  if (customElementsV1) {
-    window.customElements.define(name, function customElemMock () {}); // eslint-disable-line prefer-arrow-callback
-  } else if (customElementsV0) {
-    document.registerElement(name, function customElemMock () {}); // eslint-disable-line prefer-arrow-callback
-  }
+  window.customElements.define(name, function customElemMock () {});
 }
 
 describe('api/define', () => {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -44,7 +44,6 @@ describe('exports', () => {
   it('skate.symbols', () => {
     expect(api.symbols).to.be.an('object');
     expect(api.symbols.name).to.equal(symbols.name);
-    expect(api.symbols.shadowRoot).to.equal(symbols.shadowRoot);
   });
 
   it('skate.h', () => {

--- a/test/unit/vdom/elements.js
+++ b/test/unit/vdom/elements.js
@@ -24,7 +24,7 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element('div'));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
           done
         );
       });
@@ -34,7 +34,7 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element(Ctor));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
           done
         );
       });
@@ -43,8 +43,8 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element('div', 'text'));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -53,8 +53,8 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element('div', vdom.text.bind(null, 'text')));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -64,8 +64,8 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element(Ctor, 'text'));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -75,8 +75,8 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element(Ctor, vdom.text.bind(null, 'text')));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -85,9 +85,9 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element('div', { id: 'test' }, 'text'));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.id).to.equal('test'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -96,9 +96,9 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element('div', { id: 'test' }, vdom.text.bind(null, 'text')));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.id).to.equal('test'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -108,9 +108,9 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element(Ctor, { id: 'test' }, 'text'));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.id).to.equal('test'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -120,9 +120,9 @@ describe('vdom/elements', () => {
         const elem = create(() => vdom.element(Ctor, { id: 'test' }, vdom.text.bind(null, 'text')));
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].firstChild.tagName).to.equal('DIV'),
-          () => expect(elem[symbols.shadowRoot].firstChild.id).to.equal('test'),
-          () => expect(elem[symbols.shadowRoot].firstChild.textContent).to.equal('text'),
+          () => expect(elem.shadowRoot.firstChild.tagName).to.equal('DIV'),
+          () => expect(elem.shadowRoot.firstChild.id).to.equal('test'),
+          () => expect(elem.shadowRoot.firstChild.textContent).to.equal('text'),
           done
         );
       });
@@ -156,7 +156,7 @@ describe('vdom/elements', () => {
     fixture().appendChild(elem1);
     afterMutations(
       () => {}, // .render()
-      () => expect(elem2[symbols.shadowRoot].textContent).to.equal('rendered'),
+      () => expect(elem2.shadowRoot.textContent).to.equal('rendered'),
       done
     );
   });
@@ -177,7 +177,7 @@ describe('vdom/elements', () => {
         fixture().appendChild(elem);
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
+          () => expect(elem.shadowRoot.innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
       });
@@ -195,7 +195,7 @@ describe('vdom/elements', () => {
         fixture().appendChild(elem);
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
+          () => expect(elem.shadowRoot.innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
       });
@@ -213,7 +213,7 @@ describe('vdom/elements', () => {
         fixture().appendChild(elem);
         afterMutations(
           () => {}, // .render()
-          () => expect(elem[symbols.shadowRoot].innerHTML).to.equal(`<div><span>${ch}</span></div>`),
+          () => expect(elem.shadowRoot.innerHTML).to.equal(`<div><span>${ch}</span></div>`),
           done
         );
       });
@@ -234,7 +234,7 @@ describe('vdom/elements', () => {
       fixture().appendChild(elem);
       afterMutations(
         () => {}, // .render()
-        () => expect(elem[symbols.shadowRoot].innerHTML).to.equal('<ul><li><a>Item 1</a></li><li><a>Item 2</a></li></ul>'),
+        () => expect(elem.shadowRoot.innerHTML).to.equal('<ul><li><a>Item 1</a></li><li><a>Item 2</a></li></ul>'),
         done
       );
     });
@@ -259,9 +259,9 @@ describe('vdom/elements', () => {
       fixture().appendChild(elem);
       afterMutations(
         () => {}, // .render()
-        () => expect(elem[symbols.shadowRoot].innerHTML).to.equal('<div></div>'),
+        () => expect(elem.shadowRoot.innerHTML).to.equal('<div></div>'),
         () => {
-          const div = elem[symbols.shadowRoot];
+          const div = elem.shadowRoot;
           expect(div.key).to.equal(undefined);
           expect(div.ref).to.equal(undefined);
           expect(div.statics).to.equal(undefined);

--- a/test/unit/vdom/elements.js
+++ b/test/unit/vdom/elements.js
@@ -3,7 +3,6 @@
 import afterMutations from '../../lib/after-mutations';
 import element from '../../lib/element';
 import fixture from '../../lib/fixture';
-import { shadowDomV0, shadowDomV1 } from '../../../src/util/support';
 import { symbols, vdom } from '../../../src/index';
 
 describe('vdom/elements', () => {
@@ -134,49 +133,6 @@ describe('vdom/elements', () => {
         });
       });
     });
-  });
-
-  it('slot', (done) => {
-    const elem1 = new (element().skate({
-      render () {
-        vdom.element('slot', { name: 'test' });
-      }
-    }))();
-    const elem2 = new (element().skate({
-      render () {
-        vdom.element('slot', { name: 'test' });
-      }
-    }))();
-
-    fixture().appendChild(elem1);
-    fixture().appendChild(elem2);
-
-    afterMutations(
-      () => {}, // .render()
-      () => {
-        const ch1 = elem1[symbols.shadowRoot].firstElementChild;
-        const ch2 = elem2[symbols.shadowRoot].firstElementChild;
-
-        function assertSlotElement () {
-          expect(ch1.tagName).to.equal('SLOT', 'vdom');
-          expect(ch1.getAttribute('name')).to.equal('test', 'vdom');
-          expect(ch2.tagName).to.equal('SLOT', 'vdom.element(slot)');
-          expect(ch2.getAttribute('name')).to.equal('test', 'vdom.element(slot)');
-        }
-
-        if (shadowDomV1) {
-          assertSlotElement();
-        } else if (shadowDomV0) {
-          expect(ch1.tagName).to.equal('CONTENT', 'vdom');
-          expect(ch1.getAttribute('select')).to.equal('[slot="test"]', 'vdom');
-          expect(ch2.tagName).to.equal('CONTENT', 'vdom.element(slot)');
-          expect(ch2.getAttribute('select')).to.equal('[slot="test"]', 'vdom.element(slot)');
-        } else {
-          assertSlotElement();
-        }
-      },
-      done
-    );
   });
 
   it('passing a component constructor to the vdom.element() function', (done) => {

--- a/test/unit/vdom/events.js
+++ b/test/unit/vdom/events.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine, mocha */
 
-import { emit, prop, props, symbols, vdom } from '../../../src/index';
+import { emit, prop, props, vdom } from '../../../src/index';
 import afterMutations from '../../lib/after-mutations';
 import element from '../../lib/element';
 import fixture from '../../lib/fixture';

--- a/test/unit/vdom/events.js
+++ b/test/unit/vdom/events.js
@@ -31,7 +31,7 @@ describe('vdom/events (on*)', () => {
     afterMutations(
       () => {}, // .render()
       () => {
-        const shadowDiv = el[symbols.shadowRoot].children[0];
+        const shadowDiv = el.shadowRoot.children[0];
 
         // Ensures that it rendered.
         expect(shadowDiv.textContent).to.equal('0');
@@ -73,7 +73,7 @@ describe('vdom/events (on*)', () => {
     afterMutations(
       () => {}, // .render()
       () => {
-        emit(myel[symbols.shadowRoot].querySelector('span'), 'test');
+        emit(myel.shadowRoot.querySelector('span'), 'test');
         expect(called).to.equal(true);
       },
       done
@@ -98,7 +98,7 @@ describe('vdom/events (on*)', () => {
     afterMutations(
       () => {}, // .render()
       () => {
-        emit(myel[symbols.shadowRoot].querySelector('span'), 'test', { detail: 'detail' });
+        emit(myel.shadowRoot.querySelector('span'), 'test', { detail: 'detail' });
         expect(called).to.equal(true);
         expect(detail).to.equal('detail');
       },
@@ -116,7 +116,7 @@ describe('vdom/events (on*)', () => {
     afterMutations(
       () => {}, // .render()
       () => {
-        emit(myel[symbols.shadowRoot].firstChild, 'test');
+        emit(myel.shadowRoot.firstChild, 'test');
       },
       done
     );
@@ -149,7 +149,7 @@ describe('vdom/events (on*)', () => {
       afterMutations(
         () => {}, // .render()
         () => {
-          div = el[symbols.shadowRoot].firstChild;
+          div = el.shadowRoot.firstChild;
         },
         done
       );

--- a/test/unit/vdom/properties.js
+++ b/test/unit/vdom/properties.js
@@ -2,7 +2,7 @@
 
 import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
-import { define, prop, props, symbols, vdom } from '../../../src/index';
+import { define, prop, props, vdom } from '../../../src/index';
 
 describe('vdom/properties', () => {
   it('class -> className', done => {
@@ -14,7 +14,7 @@ describe('vdom/properties', () => {
     fixture(elem);
     afterMutations(
       () => {}, // x-test.render()
-      () => expect(elem[symbols.shadowRoot].firstChild.className).to.equal('test'),
+      () => expect(elem.shadowRoot.firstChild.className).to.equal('test'),
       done
     );
   });
@@ -35,7 +35,7 @@ describe('vdom/properties', () => {
 
     afterMutations(
       () => {}, // x-test.render()
-      () => expect(elem[symbols.shadowRoot].firstChild.getAttribute('class')).to.equal('inner'),
+      () => expect(elem.shadowRoot.firstChild.getAttribute('class')).to.equal('inner'),
       done
     );
   });
@@ -53,7 +53,7 @@ describe('vdom/properties', () => {
     let div;
     afterMutations(
       () => {}, // x-test.render()
-      () => (div = elem[symbols.shadowRoot].firstChild),
+      () => (div = elem.shadowRoot.firstChild),
       () => (elem.test = true),
       () => expect(div.hasAttribute('test')).to.equal(true),
       () => (elem.test = false),
@@ -98,7 +98,7 @@ describe('vdom/properties', () => {
     });
 
     function text (elem) {
-      return elem[symbols.shadowRoot].firstChild[symbols.shadowRoot].textContent;
+      return elem.shadowRoot.firstChild.shadowRoot.textContent;
     }
 
     it('boolean: false -> true -> false', done => {

--- a/test/unit/vdom/shadow-dom.js
+++ b/test/unit/vdom/shadow-dom.js
@@ -1,8 +1,9 @@
 /* eslint-env jasmine, mocha */
 
-import { shadowDomV0, shadowDomV1 } from '../../../src/util/support';
 import { symbols } from '../../../src/index';
 import element from '../../lib/element';
+
+const { ShadowRoot } = window;
 
 describe('vdom/shadow-dom', () => {
   let Elem;
@@ -11,24 +12,12 @@ describe('vdom/shadow-dom', () => {
     Elem = element().skate({ render () {} });
   });
 
-  if (shadowDomV0) {
-    it('should work for createShadowRoot()', () => {
-      const elem = new Elem();
+  it('should work for attachShadow()', () => {
+    const elem = new Elem();
+    if (elem.attachShadow) {
       expect(elem[symbols.shadowRoot]).not.to.equal(elem);
-    });
-  }
-
-  if (shadowDomV1) {
-    it('should work for attachShadow()', () => {
-      const elem = new Elem();
-      expect(elem[symbols.shadowRoot]).not.to.equal(elem);
-    });
-  }
-
-  if (!(shadowDomV0 || shadowDomV1)) {
-    it('should set the shadowRoot to the element if Shadow DOM is not available', () => {
-      const elem = new Elem();
+    } else {
       expect(elem[symbols.shadowRoot]).to.equal(elem);
-    });
-  }
+    }
+  });
 });

--- a/test/unit/vdom/shadow-dom.js
+++ b/test/unit/vdom/shadow-dom.js
@@ -1,6 +1,5 @@
 /* eslint-env jasmine, mocha */
 
-import { symbols } from '../../../src/index';
 import element from '../../lib/element';
 
 const { ShadowRoot } = window;
@@ -15,9 +14,9 @@ describe('vdom/shadow-dom', () => {
   it('should work for attachShadow()', () => {
     const elem = new Elem();
     if (elem.attachShadow) {
-      expect(elem[symbols.shadowRoot]).not.to.equal(elem);
+      expect(elem.shadowRoot).not.to.equal(elem);
     } else {
-      expect(elem[symbols.shadowRoot]).to.equal(elem);
+      expect(elem.shadowRoot).to.equal(elem);
     }
   });
 });

--- a/test/unit/vdom/shadow-dom.js
+++ b/test/unit/vdom/shadow-dom.js
@@ -2,8 +2,6 @@
 
 import element from '../../lib/element';
 
-const { ShadowRoot } = window;
-
 describe('vdom/shadow-dom', () => {
   let Elem;
 
@@ -13,10 +11,6 @@ describe('vdom/shadow-dom', () => {
 
   it('should work for attachShadow()', () => {
     const elem = new Elem();
-    if (elem.attachShadow) {
-      expect(elem.shadowRoot).not.to.equal(elem);
-    } else {
-      expect(elem.shadowRoot).to.equal(elem);
-    }
+    expect(elem.shadowRoot).not.to.equal(elem);
   });
 });

--- a/test/unit/vdom/skip.js
+++ b/test/unit/vdom/skip.js
@@ -1,11 +1,11 @@
 /* eslint-env jasmine, mocha, chai */
 
-import { define, prop, props, symbols, vdom } from '../../../src/index';
+import { define, prop, props, vdom } from '../../../src/index';
 import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
 
 const { text, elementOpen, elementClose, elementOpenStart, elementOpenEnd, elementVoid } = vdom;
-const sr = el => el[symbols.shadowRoot];
+const sr = el => el.shadowRoot;
 
 describe('vdom/skip', () => {
   it('should skip the element children', done => {
@@ -101,15 +101,15 @@ describe('vdom/skip', () => {
     fixture(elem);
     afterMutations(
       () => {}, // x-test.render()
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('222'),
+      () => expect(elem.shadowRoot.textContent).to.equal('222'),
       () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('222'),
+      () => expect(elem.shadowRoot.textContent).to.equal('222'),
       () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('444'),
+      () => expect(elem.shadowRoot.textContent).to.equal('444'),
       () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('444'),
+      () => expect(elem.shadowRoot.textContent).to.equal('444'),
       () => props(elem, { num: elem.num + 1 }),
-      () => expect(elem[symbols.shadowRoot].textContent).to.equal('666'),
+      () => expect(elem.shadowRoot.textContent).to.equal('666'),
       done
     );
   });
@@ -128,9 +128,9 @@ describe('vdom/skip', () => {
     fixture(elem);
     afterMutations(
       () => {}, // x-test.render()
-      () => (elem[symbols.shadowRoot].firstElementChild.textContent = 'testing'),
+      () => (elem.shadowRoot.firstElementChild.textContent = 'testing'),
       () => props(elem, { test: 0 }),
-      () => expect(elem[symbols.shadowRoot].firstElementChild.textContent).to.equal('testing'),
+      () => expect(elem.shadowRoot.firstElementChild.textContent).to.equal('testing'),
       done
     );
   });
@@ -148,9 +148,9 @@ describe('vdom/skip', () => {
     fixture(elem);
     afterMutations(
       () => {}, // x-test.render()
-      () => (elem[symbols.shadowRoot].firstElementChild.textContent = 'testing'),
+      () => (elem.shadowRoot.firstElementChild.textContent = 'testing'),
       () => props(elem, { test: 0 }),
-      () => expect(elem[symbols.shadowRoot].firstElementChild.textContent).to.equal('testing'),
+      () => expect(elem.shadowRoot.firstElementChild.textContent).to.equal('testing'),
       done
     );
   });


### PR DESCRIPTION
Fixes #710.

Since v1 is support in Chrome, there's no need to support v0 even if Opera hasn't updated yet. Until they pick up the new Blink (if they haven't already) people wanting to support opera can use the polyfills.