### PR TITLE
fix(util): fix mobile safari 9.0 - mo + microtask debounce

### DIFF
--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -16,8 +16,8 @@ function microtaskDebounce (cbFunc) {
   observer.observe(elem, { childList: true });
 
   return (...args) => {
+    cbArgs = args;
     if (!called) {
-      cbArgs = args;
       called = true;
       elem.textContent = `${i}`;
       i += 1;
@@ -43,5 +43,4 @@ function taskDebounce (cbFunc) {
     }
   };
 }
-
 export default native(MutationObserver) ? microtaskDebounce : taskDebounce;

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -32,13 +32,15 @@ function microtaskDebounce (cbFunc) {
 // The soonest we can set the timeout for in IE is 1 as they have issues when
 // setting to 0.
 function taskDebounce (cbFunc) {
-  let called = false;
+  let scheduled = false;
+  let cbArgs = [];
   return (...args) => {
-    if (!called) {
-      called = true;
+    cbArgs = args;
+    if (!scheduled) {
+      scheduled = true;
       setTimeout(() => {
-        called = false;
-        cbFunc(...args);
+        scheduled = false;
+        cbFunc(...cbArgs);
       }, 1);
     }
   };

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -3,13 +3,13 @@ import native from './native';
 const { MutationObserver } = window;
 
 function microtaskDebounce (cbFunc) {
-  let called = false;
+  let scheduled = false;
   let i = 0;
   let cbArgs = [];
   const elem = document.createElement('span');
   const observer = new MutationObserver(() => {
     cbFunc(...cbArgs);
-    called = false;
+    scheduled = false;
     cbArgs = null;
   });
 
@@ -17,8 +17,8 @@ function microtaskDebounce (cbFunc) {
 
   return (...args) => {
     cbArgs = args;
-    if (!called) {
-      called = true;
+    if (!scheduled) {
+      scheduled = true;
       elem.textContent = `${i}`;
       i += 1;
     }

--- a/src/util/native.js
+++ b/src/util/native.js
@@ -1,1 +1,7 @@
-export default fn => (fn || '').toString().indexOf(['native code']) > -1;
+const nativeHints = [
+  'native code',
+  '[object MutationObserverConstructor]', // for mobile safari iOS 9.0
+];
+export default fn => nativeHints.map(
+  (hint) => (fn || '').toString().indexOf([hint]) > -1
+).reduce((a, b) => a || b);

--- a/src/util/native.js
+++ b/src/util/native.js
@@ -1,6 +1,6 @@
 const nativeHints = [
   'native code',
-  '[object MutationObserverConstructor]', // for mobile safari iOS 9.0
+  '[object MutationObserverConstructor]' // for mobile safari iOS 9.0
 ];
 export default fn => nativeHints.map(
   (hint) => (fn || '').toString().indexOf([hint]) > -1

--- a/test/unit/util/debounce.js
+++ b/test/unit/util/debounce.js
@@ -1,0 +1,29 @@
+/* eslint-env jasmine, mocha */
+
+import debounce from '../../../src/util/debounce';
+
+describe('utils/debounce', () => {
+  it('should be called only once', (done) => {
+    let i = 0;
+    const debounced = debounce(() => (i++));
+    debounced();
+    debounced();
+    debounced();
+    setTimeout(() => {
+      expect(i).to.equal(1, 'debounce is called only once');
+      done();
+    }, 1);
+  });
+
+  it('should be called with the correct arguments', (done) => {
+    let arg;
+    const debounced = debounce((x) => (arg = x));
+    debounced(1);
+    debounced(2);
+    debounced(3);
+    setTimeout(() => {
+      expect(arg).to.equal(3, 'debounce is called with the last argument');
+      done();
+    }, 1);
+  });
+});

--- a/test/unit/util/native.js
+++ b/test/unit/util/native.js
@@ -1,0 +1,19 @@
+/* eslint-env jasmine, mocha */
+
+import native from '../../../src/util/native';
+
+describe('utils/native', () => {
+  it('Should return true for Chrome native MutationObserver', () => {
+    expect(native({
+      toString: () => 'function MutationObserver() { [native code] }'
+    })).to.equal(true);
+  });
+  it('Should return true for Safari native MutationObserver', () => {
+    expect(native({
+      toString: () => '[object MutationObserverConstructor]'
+    })).to.equal(true);
+  });
+  it('Should return false for a non native function', () => {
+    expect(native(() => null)).to.equal(false);
+  });
+});


### PR DESCRIPTION
native MutationObserver feature detection was incorrect for mobile safari 9.0 . Also, microtasks

were not debounced correctly