### PR TITLE
#931 - Use Flow for Development

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+.*/node\_modules/esformatter/test/.*
+.*/node\_modules/config\-chain/test/.*
+.*/node\_modules/flow\-remove\-types/test/.*
+.*/node\_modules/npm/test/.*
+.*/node\_modules/npmconf/test/.*
+
+[include]
+
+[libs]
+flow/
+
+[options]
+unsafe.enable_getters_and_setters=true

--- a/flow/interfaces.js
+++ b/flow/interfaces.js
@@ -1,0 +1,26 @@
+declare interface IGetData {
+  name:string|Symbol;
+  internalValue:any;
+}
+
+declare interface ISetData {
+  name:string|Symbol;
+  newValue:any;
+  oldValue:any;
+}
+
+/**
+ * Property Configuration
+ * The options that can be used when configuring a property with skate
+ * Note: every member of this interface is optional!
+ */
+declare interface IPropConfig {
+  attribute?: boolean|string;
+  coerce?: (v:any) => any;
+  default?: any; //|(elem:any, data:any) => any;
+  deserialize?: (v:?string) => any;
+  get?: (elem:any, data:IGetData) => any;
+  initial?: any; //|(elem:any, data:any) => any;
+  serialize?: (v:any) => ?string;
+  set?: (elem:any, data:ISetData) => void;
+}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   },
   "devDependencies": {
     "birdpoo": "0.x",
+    "flow": "0.2.3",
     "react": "15.4.0",
     "react-dom": "15.4.0",
-    "skatejs-build": "12.x",
+    "skatejs-build": "12.1.x",
     "skatejs-web-components": "5.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "window-or-global": "1.0.1"
   },
   "devDependencies": {
+    "babel-plugin-transform-flow-strip-types": "^6.18.0",
     "birdpoo": "0.x",
     "flow": "0.2.3",
     "react": "15.4.0",
     "react-dom": "15.4.0",
-    "skatejs-build": "12.1.x",
+    "skatejs-build": "12.1.0",
     "skatejs-web-components": "5.x"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,14 @@
-const rollupBabel = require('rollup-plugin-babel');
-const presetEs2015 = require('babel-preset-es2015-rollup');
-
-const babel = rollupBabel({
-  presets: presetEs2015,
-  plugins: ['transform-flow-strip-types']
-});
-
 module.exports = require('skatejs-build/rollup.config');
 module.exports.globals = {
   'incremental-dom': 'IncrementalDOM',
   'window-or-global': 'windowOrGlobal'
 };
+
+// This should be part of the default skatejs/build
+const rollupBabel = require('rollup-plugin-babel');
+const presetEs2015 = require('babel-preset-es2015-rollup');
+const babel = rollupBabel({
+  presets: presetEs2015,
+  plugins: ['transform-flow-strip-types']
+});
 module.exports.plugins[0] = babel;
-console.log('>>> rollup', babel);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,15 @@
+const rollupBabel = require('rollup-plugin-babel');
+const presetEs2015 = require('babel-preset-es2015-rollup');
+
+const babel = rollupBabel({
+  presets: presetEs2015,
+  plugins: ['transform-flow-strip-types']
+});
+
 module.exports = require('skatejs-build/rollup.config');
 module.exports.globals = {
   'incremental-dom': 'IncrementalDOM',
   'window-or-global': 'windowOrGlobal'
 };
-
-console.log('>>> rollup', module.exports.plugins[0]);
+module.exports.plugins[0] = babel;
+console.log('>>> rollup', babel);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,3 +3,5 @@ module.exports.globals = {
   'incremental-dom': 'IncrementalDOM',
   'window-or-global': 'windowOrGlobal'
 };
+
+console.log('>>> rollup', module.exports.plugins[0]);

--- a/src/api/prop.js
+++ b/src/api/prop.js
@@ -1,38 +1,46 @@
+//@flow
 import assign from '../util/assign';
 import empty from '../util/empty';
 
 const alwaysUndefinedIfNotANumberOrNumber = val => (isNaN(val) ? undefined : Number(val));
 const alwaysUndefinedIfEmptyOrString = val => (empty(val) ? undefined : String(val));
 
-export function create (def) {
-  return (...args) => {
-    args.unshift({}, def);
+/**
+ * Returns a function to create Property Configurations based on the
+ * given template Property Configuration that provides some default options.
+ */
+export function create(template:IPropConfig) {
+  //todo: where this is called will more than on argument?
+  return (...args:IPropConfig[]) => {
+    args.unshift({}, template);
     return assign(...args);
   };
 }
 
-export const array = create({
+export const array:IPropConfig = create({
   coerce: val => (Array.isArray(val) ? val : [val]),
   default: () => [],
-  deserialize: JSON.parse,
+  // Note: JSON.parse(undefined) throws Error
+  // this was detected by flow
+  deserialize: val => (val === undefined ? undefined : JSON.parse(String(val))),
   serialize: JSON.stringify
 });
 
-export const boolean = create({
+export const boolean:IPropConfig = create({
   coerce: value => !!value,
   default: false,
   deserialize: value => !(value === null),
   serialize: value => (value ? '' : undefined)
 });
 
-export const number = create({
+export const number:IPropConfig = create({
   default: 0,
   coerce: alwaysUndefinedIfNotANumberOrNumber,
   deserialize: alwaysUndefinedIfNotANumberOrNumber,
   serialize: alwaysUndefinedIfNotANumberOrNumber
 });
 
-export const string = create({
+export const string:IPropConfig = create({
   default: '',
   coerce: alwaysUndefinedIfEmptyOrString,
   deserialize: alwaysUndefinedIfEmptyOrString,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
 module.exports = require('skatejs-build/webpack.config');
 console.log('>>> webpack plugins before', module.exports.module.loaders[2].query.plugins);
-module.exports.module.loaders[2].query.plugins = ['transform-flow-strip-types', 'transform-class-properties'];
+module.exports.module.loaders[2].query.plugins = ['transform-class-properties', 'transform-flow-strip-types'];
 console.log('>>> webpack plugins after', module.exports.module.loaders[2].query.plugins);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,2 +1,2 @@
 module.exports = require('skatejs-build/webpack.config');
-module.exports.module.loaders[2].query.plugins = ['transform-class-properties'];
+module.exports.module.loaders[2].query.plugins = ['transform-class-properties', 'transform-flow-strip-types'];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,2 +1,4 @@
 module.exports = require('skatejs-build/webpack.config');
-module.exports.module.loaders[2].query.plugins = ['transform-class-properties', 'transform-flow-strip-types'];
+console.log('>>> webpack plugins before', module.exports.module.loaders[2].query.plugins);
+module.exports.module.loaders[2].query.plugins = ['transform-flow-strip-types', 'transform-class-properties'];
+console.log('>>> webpack plugins after', module.exports.module.loaders[2].query.plugins);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,2 @@
 module.exports = require('skatejs-build/webpack.config');
-console.log('>>> webpack plugins before', module.exports.module.loaders[2].query.plugins);
 module.exports.module.loaders[2].query.plugins = ['transform-class-properties', 'transform-flow-strip-types'];
-console.log('>>> webpack plugins after', module.exports.module.loaders[2].query.plugins);


### PR DESCRIPTION
This PR is to propose that we use Flow to help the team be more productive and make the code more expressive for others to understand and start to contribute more.
This is mostly for the benefit to the developers that maintain the SkateJs library and at least at this point, it is NOT for the users of the library.

One alternative could be TypeScript.
The choice is really between ES6+Flow   vs.   TypeScript 

TypeScript adds a level of abstraction. 
Flow only adds annotations to the existing ES6 code.

Syntactically they both looks quite similar.

I vote for Flow, because I think it is beneficial for SkateJs to stay with ES6 + Babel.
It is best to stay closer to the platform when dealing with buggy Polyfills or buggy browser native implementations.

I let the Team vote…
