### PR TITLE
#957 - class PropDefinition holds prop name and normalized prop options

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ The parameters passed to the function are:
 
 #### `default`
 
-Specifies the default value of the property. If the property is ever set to `null` or `undefined`, instead of being empty, the `default` value will be used instead.
+Specifies the default value of the property. If the property is ever set to `null` or `undefined`, instead of being set to 'null', the `default` value will be used instead.
 
 ```js
 customElements.define('my-component', class extends skate.Component {
@@ -681,7 +681,7 @@ The parameters passed to the function are:
   - `newValue` - the new property value
   - `oldValue` - the old property value.
 
-When the property is initialised, `oldValue` will always be `undefined` and `newValue` will correspond to the initial value. If the property is set to `null` or `undefined`, the value is normalised to be `undefined` for consistency.
+When the property is initialised, `oldValue` will always be `null` and `newValue` will correspond to the initial value. If the property is set to `null` or `undefined`, the `oldValue` is again normalised to be `null` for consistency.
 
 *An important thing to note is that native property setters are not invoked if you use the `delete` keyword. For that reason, Skate property setters are also not able to be invoked, so keep this in mind when using your components.*
 
@@ -1045,9 +1045,9 @@ skate.prop.boolean({
 });
 ```
 
-Generally built-in properties will only return a definition containing `coerce`, `deserialize` and `serialize` options. They may also define a `deafult`, such as with the `boolean` property.
+Generally built-in properties return a definition containing `default`, `coerce`, `deserialize` and `serialize` options.
 
-*Empty values are defined as `null` or `undefined`. All empty values, if the property accepts them, are normalised to `undefined`.
+*Empty values are defined as `null` or `undefined`. All empty values, if the property accepts them, are normalised to `null`.
 
 *Properties are only linked to attributes if the `attribute` option is set. Each built-in property, if possible, will supply a `deserialize` and `serialize` option but will not be linked by default.*
 

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -21,6 +21,7 @@ import getPropsMap from '../util/get-props-map';
 import getSetProps from './props';
 import { createNativePropertyDescriptor } from '../lifecycle/props-init';
 import { isFunction } from '../util/isType';
+import objectIs from '../util/object-is';
 import setCtorNativeProperty from '../util/set-ctor-native-property';
 import syncPropToAttr from '../util/sync-prop-to-attr';
 import root from 'window-or-global';
@@ -292,7 +293,7 @@ export default class extends HTMLElement {
     for (let i = 0; i < allKeys.length; i++) {
       const nameOrSymbol = allKeys[i];
       // Object.is (NaN is equal NaN)
-      if (!Object.is(prevProps[nameOrSymbol], this[nameOrSymbol])) {
+      if (!objectIs(prevProps[nameOrSymbol], this[nameOrSymbol])) {
         return true;
       }
     }

--- a/src/api/prop.js
+++ b/src/api/prop.js
@@ -1,8 +1,9 @@
 import assign from '../util/assign';
 import empty from '../util/empty';
 
-const alwaysUndefinedIfNotANumberOrNumber = val => (isNaN(val) ? undefined : Number(val));
-const alwaysUndefinedIfEmptyOrString = val => (empty(val) ? undefined : String(val));
+// defaults empty to 0 and allow NaN
+const zeroIfEmptyOrNumberIncludesNaN = val => (empty(val) ? 0 : Number(val));
+const nullIfEmptyOrString = val => (empty(val) ? null : String(val));
 
 export function create (def) {
   return (...args) => {
@@ -12,29 +13,32 @@ export function create (def) {
 }
 
 export const array = create({
-  coerce: val => (Array.isArray(val) ? val : [val]),
+  coerce: val => (Array.isArray(val) ? val : (empty(val) ? null : [val])),
   default: () => [],
-  deserialize: JSON.parse,
+  deserialize: val => (empty(val) ? null : JSON.parse(val)),
   serialize: JSON.stringify
 });
 
 export const boolean = create({
-  coerce: value => !!value,
+  coerce: val => !!val,
   default: false,
-  deserialize: value => !(value === null),
-  serialize: value => (value ? '' : undefined)
+  // todo: 'false' string must deserialize to false for angular 1.x to work
+  // This breaks one existing test.
+  // deserialize: val => !(val === null || val === 'false'),
+  deserialize: val => !(val === null),
+  serialize: val => (val ? '' : null)
 });
 
 export const number = create({
   default: 0,
-  coerce: alwaysUndefinedIfNotANumberOrNumber,
-  deserialize: alwaysUndefinedIfNotANumberOrNumber,
-  serialize: alwaysUndefinedIfNotANumberOrNumber
+  coerce: zeroIfEmptyOrNumberIncludesNaN,
+  deserialize: zeroIfEmptyOrNumberIncludesNaN,
+  serialize: nullIfEmptyOrString
 });
 
 export const string = create({
   default: '',
-  coerce: alwaysUndefinedIfEmptyOrString,
-  deserialize: alwaysUndefinedIfEmptyOrString,
-  serialize: alwaysUndefinedIfEmptyOrString
+  coerce: nullIfEmptyOrString,
+  deserialize: nullIfEmptyOrString,
+  serialize: nullIfEmptyOrString
 });

--- a/src/api/props.js
+++ b/src/api/props.js
@@ -1,12 +1,13 @@
 import { renderer as $renderer } from '../util/symbols';
 import assign from '../util/assign';
 import getPropsMap from '../util/get-props-map';
-import keys from '../util/get-all-keys';
+import getAllKeys from '../util/get-all-keys';
 
 function get (elem) {
   const props = {};
-  keys(getPropsMap(elem.constructor)).forEach((key) => {
-    props[key] = elem[key];
+
+  getAllKeys(getPropsMap(elem.constructor)).forEach((propNameOrSymbol) => {
+    props[propNameOrSymbol] = elem[propNameOrSymbol];
   });
 
   return props;

--- a/src/lifecycle/props-init.js
+++ b/src/lifecycle/props-init.js
@@ -2,16 +2,16 @@ import {
   connected as $connected,
   rendererDebounced as $rendererDebounced
 } from '../util/symbols';
-import assign from '../util/assign';
 import data from '../util/data';
 import empty from '../util/empty';
-import dashCase from '../util/dash-case';
 import getDefaultValue from '../util/get-default-value';
 import getInitialValue from '../util/get-initial-value';
 import getPropData from '../util/get-prop-data';
 import syncPropToAttr from '../util/sync-prop-to-attr';
 
-function createNativePropertyDefinition (name, opts) {
+export function createNativePropertyDescriptor (propDef) {
+  const name = propDef.name;
+
   const prop = {
     configurable: true,
     enumerable: true
@@ -19,31 +19,32 @@ function createNativePropertyDefinition (name, opts) {
 
   prop.created = function created (elem) {
     const propData = getPropData(elem, name);
-    const attributeName = opts.attribute === true ? dashCase(name) : opts.attribute;
+    const attrName = propDef.attrName;
     let initialValue = elem[name];
 
     // Store property to attribute link information.
-    data(elem, 'attributeLinks')[attributeName] = name;
-    data(elem, 'propertyLinks')[name] = attributeName;
+    if (attrName) {
+      data(elem, 'attributeLinks')[attrName] = name;
+    }
 
     // Set up initial value if it wasn't specified.
     if (empty(initialValue)) {
-      if (attributeName && elem.hasAttribute(attributeName)) {
-        initialValue = opts.deserialize(elem.getAttribute(attributeName));
-      } else if ('initial' in opts) {
-        initialValue = getInitialValue(elem, name, opts);
-      } else if ('default' in opts) {
-        initialValue = getDefaultValue(elem, name, opts);
+      if (attrName && elem.hasAttribute(attrName)) {
+        initialValue = propDef.deserialize(elem.getAttribute(attrName));
+      } else if ('initial' in propDef) {
+        initialValue = getInitialValue(elem, propDef);
+      } else {
+        initialValue = getDefaultValue(elem, propDef);
       }
     }
 
-    propData.internalValue = opts.coerce ? opts.coerce(initialValue) : initialValue;
+    propData.internalValue = propDef.coerce ? propDef.coerce(initialValue) : initialValue;
   };
 
   prop.get = function get () {
     const propData = getPropData(this, name);
     const { internalValue } = propData;
-    return typeof opts.get === 'function' ? opts.get(this, { name, internalValue }) : internalValue;
+    return propDef.get ? propDef.get(this, { name, internalValue }) : internalValue;
   };
 
   prop.set = function set (newValue) {
@@ -56,17 +57,17 @@ function createNativePropertyDefinition (name, opts) {
     }
 
     if (empty(newValue)) {
-      newValue = getDefaultValue(this, name, opts);
+      newValue = getDefaultValue(this, propDef);
     }
 
-    if (typeof opts.coerce === 'function') {
-      newValue = opts.coerce(newValue);
+    if (propDef.coerce) {
+      newValue = propDef.coerce(newValue);
     }
 
     const changeData = { name, newValue, oldValue };
 
-    if (typeof opts.set === 'function') {
-      opts.set(this, changeData);
+    if (propDef.set) {
+      propDef.set(this, changeData);
     }
 
     // Queue a re-render.
@@ -77,23 +78,9 @@ function createNativePropertyDefinition (name, opts) {
 
     // Link up the attribute.
     if (this[$connected]) {
-      syncPropToAttr(this, opts, name, false);
+      syncPropToAttr(this, propDef, false);
     }
   };
 
   return prop;
-}
-
-export default function (opts) {
-  opts = opts || {};
-
-  if (typeof opts === 'function') {
-    opts = { coerce: opts };
-  }
-
-  return name => createNativePropertyDefinition(name, assign({
-    default: null,
-    deserialize: value => value,
-    serialize: value => value
-  }, opts));
 }

--- a/src/util/get-default-value.js
+++ b/src/util/get-default-value.js
@@ -1,3 +1,5 @@
-export default function getDefaultValue (elem, name, opts) {
-  return typeof opts.default === 'function' ? opts.default(elem, { name }) : opts.default;
+export default function getDefaultValue (elem, propDef) {
+  return typeof propDef.default === 'function'
+    ? propDef.default(elem, { name: propDef.name })
+    : propDef.default;
 }

--- a/src/util/get-initial-value.js
+++ b/src/util/get-initial-value.js
@@ -1,3 +1,5 @@
-export default function getInitialValue (elem, name, opts) {
-  return typeof opts.initial === 'function' ? opts.initial(elem, { name }) : opts.initial;
+export default function getInitialValue (elem, propDef) {
+  return typeof propDef.initial === 'function'
+    ? propDef.initial(elem, { name: propDef.name })
+    : propDef.initial;
 }

--- a/src/util/get-props-map.js
+++ b/src/util/get-props-map.js
@@ -2,13 +2,14 @@ import {
   ctorPropsMap as $ctorPropsMap
 } from './symbols';
 import getAllKeys from './get-all-keys';
+import PropDefinition from './prop-definition';
 import setCtorNativeProperty from './set-ctor-native-property';
 
 /**
- * Returns a cached map of property options for the given component class.
+ * Memoizes a map of PropDefinition for the given component class.
  * Keys in the map are the properties name which can a string or a symbol.
  *
- * The map is created by caching the result of: static get props
+ * The map is created from the result of: static get props
  */
 export default function getPropsMap (Ctor) {
   // Must be defined on constructor and not from a superclass
@@ -16,7 +17,7 @@ export default function getPropsMap (Ctor) {
     const props = Ctor.props || {};
 
     const propsMap = getAllKeys(props).reduce((result, propNameOrSymbol) => {
-      result[propNameOrSymbol] = props[propNameOrSymbol];
+      result[propNameOrSymbol] = new PropDefinition(propNameOrSymbol, props[propNameOrSymbol]);
       return result;
     }, {});
     setCtorNativeProperty(Ctor, $ctorPropsMap, propsMap);

--- a/src/util/object-is.js
+++ b/src/util/object-is.js
@@ -1,0 +1,13 @@
+export default (x, y) => {
+  if (Object.is) {
+    return Object.is(x, y);
+  }
+  // SameValue algorithm
+  if (x === y) { // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    return x !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+};

--- a/src/util/prop-definition.js
+++ b/src/util/prop-definition.js
@@ -1,0 +1,97 @@
+import dashCase from './dash-case';
+import empty from './empty';
+
+/**
+ * @internal
+ * Property Definition
+ *
+ * Internal meta data and strategies for a property.
+ * Created from the options of a PropOptions config object.
+ *
+ * Once created a PropDefinition should be treated as immutable and final.
+ * 'getPropsMap' function memoizes PropDefinitions by Component's Class.
+ *
+ * The 'attribute' option is normalized into the 'attrName' property.
+ */
+export default class PropDefinition {
+
+  constructor (nameOrSymbol, propOptions) {
+    this._name = nameOrSymbol;
+
+    propOptions = propOptions || {};
+
+    // default 'attrName': no linked attribute
+    this.attrName = null;
+
+    // default 'coerce': don't coerce
+    this.coerce = null;
+
+    // default 'default': set prop to 'null'
+    this.default = null;
+
+    // default 'deserialize': return attribute's value (string or null)
+    this.deserialize = value => value;
+
+    // default 'get': no function
+    this.get = null;
+
+    // 'initial' default: unspecified
+    // 'initial' option is truly optional and it cannot be initialized.
+    // Its presence is tested using: ('initial' in propDef)
+
+    // 'serialize' default: return string value or null
+    this.serialize = value => (empty(value) ? null : String(value));
+
+    // default 'set': no function
+    this.set = null;
+
+    // Note: option key is always a string (no symbols here)
+    Object.keys(propOptions).forEach(option => {
+      const optVal = propOptions[option];
+
+      // Only accept documented options and perform minimal input validation.
+      switch (option) {
+        case 'attribute':
+          this.attrName = resolveAttrName(optVal, nameOrSymbol);
+          break;
+        case 'coerce':
+        case 'deserialize':
+        case 'get':
+        case 'serialize':
+        case 'set':
+          if (typeof optVal === 'function') {
+            this[option] = optVal;
+          } else {
+            console.error(option + ' must be a function.');
+          }
+          break;
+        case 'default':
+        case 'initial':
+          this[option] = optVal;
+          break;
+        default:
+          console.error(option + ' is not a valid option.');
+          break;
+      }
+    });
+  }
+
+  get name () {
+    return this._name;
+  }
+
+}
+
+function resolveAttrName (attrOption, nameOrSymbol) {
+  if (typeof nameOrSymbol === 'symbol') {
+    console.error('symbol property cannot have an attribute', nameOrSymbol);
+  } else {
+    if (attrOption === true) {
+      return dashCase(String(nameOrSymbol));
+    }
+    if (typeof attrOption === 'string') {
+      return attrOption;
+    }
+  }
+  return null;
+}

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -21,7 +21,10 @@ function testTypeValues (type, values, done) {
   afterMutations(() => {
     values.forEach((value) => {
       elem.test = value[0];
-      expect(elem.test).to.equal(value[1], 'prop value after prop set');
+      // for number comparison use Object.is where NaN is equal NaN
+      if (type !== 'number' || !Object.is(elem.test, value[1])) {
+        expect(elem.test).to.equal(value[1], 'prop value after prop set');
+      }
       expect(elem.getAttribute('test')).to.equal(value[2], 'attr value after prop set');
     });
     done();
@@ -146,7 +149,7 @@ describe('api/prop', () => {
         [null, 0, null],
         [undefined, 0, null],
         [0.1, 0.1, '0.1'],
-        ['test', undefined, null],
+        ['test', NaN, 'NaN'],
         ['', 0, '0']
       ], done);
     });

--- a/test/unit/api/properties.js
+++ b/test/unit/api/properties.js
@@ -3,6 +3,7 @@
 import { Component, define, prop } from '../../../src/index';
 import afterMutations from '../../lib/after-mutations';
 import assign from '../../../src/util/assign';
+import objectIs from '../../../src/util/object-is';
 
 function create (propLocal) {
   const el = new (define('x-test', class extends Component {
@@ -22,7 +23,7 @@ function testTypeValues (type, values, done) {
     values.forEach((value) => {
       elem.test = value[0];
       // for number comparison use Object.is where NaN is equal NaN
-      if (type !== 'number' || !Object.is(elem.test, value[1])) {
+      if (type !== 'number' || !objectIs(elem.test, value[1])) {
         expect(elem.test).to.equal(value[1], 'prop value after prop set');
       }
       expect(elem.getAttribute('test')).to.equal(value[2], 'attr value after prop set');

--- a/test/unit/lifecycle/properties.js
+++ b/test/unit/lifecycle/properties.js
@@ -3,8 +3,9 @@
 import { classStaticsInheritance } from '../../lib/support';
 import { Component, define } from '../../../src';
 import afterMutations from '../../lib/after-mutations';
+import {createNativePropertyDescriptor} from '../../../src/lifecycle/props-init';
 import fixture from '../../lib/fixture';
-import propsInit from '../../../src/lifecycle/props-init';
+import PropDefinition from '../../../src/util/prop-definition';
 import uniqueId from '../../../src/util/unique-id';
 
 describe('lifecycle/property', () => {
@@ -21,14 +22,6 @@ describe('lifecycle/property', () => {
     }
     return elem;
   }
-
-  it('should accept zero arguments', () => {
-    propsInit();
-  });
-
-  it('should return a function', () => {
-    expect(propsInit()).to.be.a('function');
-  });
 
   describe('props declared as attributes with ES2015 classes are linked', () => {
     const skip = !classStaticsInheritance();
@@ -164,8 +157,9 @@ describe('lifecycle/property', () => {
   });
 
   describe('property definition', () => {
-    function create2 () {
-      return propsInit()();
+    function create2 (opts) {
+      const propDef = new PropDefinition(opts);
+      return createNativePropertyDescriptor(propDef);
     }
 
     describe('native', () => {


### PR DESCRIPTION
With the new internal class 'PropDefinition' I have simplified a few functions.

@treshugart @Hotell @bradleyayers this PR is now ready for you to review.
Besides a pure refactor there is a small change in how NaN works for a prop.number().
Setting the prop to NaN will maintain the NaN value and serialize attribute to 'NaN' which deserializes back to NaN.
This should be a small breaking change that will not affect most common usecases.
I had to only change one test and use Object.is for testing equality of NaN equal NaN.

There was also a bit of inconsistency in the code where empty was sometimes normalized to undefined and in other places to null. Now everywhere empty is normalized to null. This didn't affect any tests.
This should also be transparent to most users since each build-in prop had a default that was preventing them to be empty and the default value of the 'default' option was null also.
boolean --> false
number --> 0
string --> ''
array --> []