### PR TITLE
fix(ts-typings): update ts typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,142 +1,21 @@
-import { Attributes, HTMLProps, Key, Ref } from './jsx';
-export { } from './jsx';
-
+// UMD library
 export as namespace skate;
 
-export type ComponentProps <El, T> = {
-  [P in keyof T]: PropOptions<El, T[P]>;
-};
+// empty reexport so user get's JSX to global
+export { } from './ts-typings/jsx';
 
-interface ComponentDefaultProps {
-  children?: VDOMElement<any>[];
-  key?: Key;
-}
-
-export interface StatelessComponent<Props> {
-  (props: Props, children?: VDOMNode): VDOMElement<any>,
-}
-export type SFC<P> = StatelessComponent<P>;
-
-interface ComponentClass<PropsType> {
-  new (props?: PropsType): Component<PropsType>;
-}
-export class Component<Props> extends HTMLElement {
-  // Special hack for own components type checking.
-  // It works in combination with ElementAttributesProperty. It placed in jsx.d.ts.
-  // more detail, see: https://www.typescriptlang.org/docs/handbook/jsx.html
-  //               and https://github.com/skatejs/skatejs/pull/952#issuecomment-264500153
-  _props: Props & ComponentDefaultProps;
-  // this is not possible yet? ... without this we have to duplicate props definition with class props definition
-  // [K in keyof Props]: Props[K],
-
-  static is: string;
-  static readonly props: ComponentProps<any, any>;
-  static readonly observedAttributes: string[];
-
-  // Custom Elements v1
-  connectedCallback(): void;
-  disconnectedCallback(): void;
-  attributeChangedCallback(name: string, oldValue: null | string, newValue: null | string): void;
-  adoptedCallback?(): void;
-
-  // SkateJS life cycle
-  updatedCallback(previousProps: { [nameOrSymbol: string]: any }): boolean | void;
-  renderCallback(): VDOMElement<any> | VDOMElement<any>[] | null;
-  renderedCallback(): void;
-
-  // SkateJS DEPRECATED
-  static created?(elem: Component<any>): void;
-  static attached?(elem: Component<any>): void;
-  static detached?(elem: Component<any>): void;
-  static attributeChanged?(elem: Component<any>, data: { name: string, oldValue: null | string, newValue: null | string }): void;
-  static updated(elem: Component<any>, prevProps: { [nameOrSymbol: string]: any }): boolean;
-  static render?(elem: Component<any>): JSX.Element | JSX.Element[] | null;
-  static rendered?(elem: Component<any>): void;
-}
-
-
-type AttributeReflectionBaseType = boolean | string;
-type AttributeReflectionConfig = AttributeReflectionBaseType | {
-  source?: AttributeReflectionBaseType,
-  target?: AttributeReflectionBaseType
-}
-export interface PropOptions<El, T> {
-  attribute?: AttributeReflectionConfig ;
-  coerce?: (value: any) => T | null | undefined;
-  default?: T | null | undefined | ((elem: El, data: { name: string; }) => T | null | undefined);
-  deserialize?: (value: string | null) => T | null | undefined;
-  get?: <R>(elem: El, data: { name: string; internalValue: T; }) => R;
-  initial?: T | null | undefined | ((elem: El, data: { name: string; }) => T | null | undefined);
-  serialize?: (value: T | null | undefined) => string | null;
-  set?: (elem: El, data: { name: string; newValue: T | null | undefined; oldValue: T | null | undefined; }) => void;
-}
-
-export var define: {
-  (name: string, ctor: Function): any;
-  (ctor: Function): any;
-};
-
-export interface EmitOptions {
-  bubbles?: boolean;
-  cancelable?: boolean;
-  composed?: boolean;
-  detail?: any;
-}
-export function emit(elem: EventTarget, name: string, opts?: EmitOptions): void;
-
-export var h: typeof vdom.element;
-
-export function link(elem: Component<any>, target?: string): (e: Event) => void;
-
-export var prop: {
-  create<T>(attr: PropOptions<any, T>): PropOptions<any, T> & ((attr: PropOptions<any, T>) => PropOptions<any, T>);
-
-  number(attr?: PropOptions<any, number>): PropOptions<any, number>;
-  boolean(attr?: PropOptions<any, boolean>): PropOptions<any, boolean>;
-  string(attr?: PropOptions<any, string>): PropOptions<any, string>;
-  array<T>(attr?: PropOptions<any, T[]>): PropOptions<any, T[]>;
-  object<T extends Object>(attr?: PropOptions<any, T>): PropOptions<any, T>;
-};
-
-export function props(elem: Component<any>, props?: any): void;
-
-export function ready(elem: Component<any>, done: (c: Component<any>) => void): void;
-
-// @DEPRECATED
-// export var symbols: any;
-
-
-//
-// VDOM Nodes
-// ----------------------------------------------------------------------
-
-export interface VDOMElement<P> {
-  type: VDOMElementType<P>;
-  props: P;
-  key: Key | null;
-}
-type VDOMText = string | number;
-type VDOMChild = VDOMElement<any> | VDOMText;
-
-// Should be Array<VDOMNode> but type aliases cannot be recursive
-type VDOMFragment = {} | Array<VDOMChild | any[] | boolean>;
-type VDOMNode = VDOMChild | VDOMFragment | boolean | null | undefined;
-
-type VDOMElementType<P> = string | { id: string } | ComponentClass<P> | SFC<P>;
-
-export var vdom: {
-
-  element<P>(type: VDOMElementType<P>, attrs?: HTMLProps<HTMLElement> | P, ...children: VDOMChild[]): VDOMElement<any>,
-  element<P>(type: VDOMElementType<P>, ...children: VDOMChild[]): VDOMElement<any>,
-
-  builder(): typeof vdom.element;
-  builder(...tags: string[]): ((attrs?: HTMLProps<HTMLElement>, ...children: VDOMChild[]) => VDOMElement<any>)[];
-
-  attr(...args: any[]): void;
-  elementClose: Function;
-  elementOpen: Function;
-  elementOpenEnd: Function;
-  elementOpenStart: Function;
-  elementVoid: Function;
-  text: Function;
-};
+// Public API
+export {
+  Component,
+  ComponentProps,
+  StatelessComponent,
+  SFC,
+  prop,
+  props,
+  ready,
+  link,
+  define,
+  emit,
+  h,
+  vdom
+} from './ts-typings/api';

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,6 +1,21 @@
+import { VDOMElement } from './index'
 export { }
 
-type HTMLProps<T extends Element> = Partial<T> & HyperscriptEventHandler<T>;
+export type Key = string | number;
+export type Ref<T> = string | ((instance: T) => any);
+
+export type HTMLProps<T extends Element> = Partial<T> & Attributes<T>;
+
+export type Attributes<T> = IncrementalDomHTMLAttributes<T> & HyperscriptHTMLAttributes & HyperscriptEventHandler<T>;
+interface IncrementalDomHTMLAttributes<T> {
+  key?: Key,
+  ref?: Ref<T>,
+  statics?: string[],
+  skip?: boolean,
+}
+interface HyperscriptHTMLAttributes {
+  class?: string,
+}
 
 interface HyperscriptEventHandler<T> {
   onAbort?: typeof HTMLElement.prototype.onabort;
@@ -85,7 +100,7 @@ declare global {
       readonly _props: Props,
     }
 
-    interface Element {
+    interface Element extends VDOMElement<any> {
     }
 
     interface IntrinsicElements {

--- a/src/ts-typings/api.d.ts
+++ b/src/ts-typings/api.d.ts
@@ -1,0 +1,138 @@
+import {Key, HTMLProps} from './common';
+
+export type ComponentProps <El, T> = {
+  [P in keyof T]: PropOptions<El, T[P]>;
+};
+
+interface ComponentDefaultProps {
+  children?: VDOMElement<any>[];
+  key?: Key;
+}
+
+export interface StatelessComponent<Props> {
+  (props: Props, children?: VDOMNode): VDOMElement<any>,
+}
+export type SFC<P> = StatelessComponent<P>;
+
+interface ComponentClass<PropsType> {
+  new (props?: PropsType): Component<PropsType>;
+}
+export class Component<Props> extends HTMLElement {
+  // Special hack for own components type checking.
+  // It works in combination with ElementAttributesProperty. It placed in jsx.d.ts.
+  // more detail, see: https://www.typescriptlang.org/docs/handbook/jsx.html
+  //               and https://github.com/skatejs/skatejs/pull/952#issuecomment-264500153
+  _props: Props & ComponentDefaultProps;
+  // this is not possible yet? ... without this we have to duplicate props definition with class props definition
+  // [K in keyof Props]: Props[K],
+
+  static readonly props: ComponentProps<any, any>;
+  static readonly observedAttributes: string[];
+
+  // Custom Elements v1
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+  attributeChangedCallback(name: string, oldValue: null | string, newValue: null | string): void;
+  adoptedCallback?(): void;
+
+  // SkateJS life cycle
+  updatedCallback(previousProps: { [nameOrSymbol: string]: any }): boolean | void;
+  renderCallback(): VDOMElement<any> | VDOMElement<any>[] | null;
+  renderedCallback(): void;
+
+  // SkateJS DEPRECATED
+  static created?(elem: Component<any>): void;
+  static attached?(elem: Component<any>): void;
+  static detached?(elem: Component<any>): void;
+  static attributeChanged?(elem: Component<any>, data: { name: string, oldValue: null | string, newValue: null | string }): void;
+  static updated(elem: Component<any>, prevProps: { [nameOrSymbol: string]: any }): boolean;
+  static render?(elem: Component<any>): VDOMElement<any> | VDOMElement<any>[] | null;
+  static rendered?(elem: Component<any>): void;
+}
+
+
+type AttributeReflectionBaseType = boolean | string;
+type AttributeReflectionConfig = AttributeReflectionBaseType | {
+  source?: AttributeReflectionBaseType,
+  target?: AttributeReflectionBaseType
+}
+export interface PropOptions<El, T> {
+  attribute?: AttributeReflectionConfig ;
+  coerce?: (value: any) => T | null | undefined;
+  default?: T | null | undefined | ((elem: El, data: { name: string; }) => T | null | undefined);
+  deserialize?: (value: string | null) => T | null | undefined;
+  get?: <R>(elem: El, data: { name: string; internalValue: T; }) => R;
+  initial?: T | null | undefined | ((elem: El, data: { name: string; }) => T | null | undefined);
+  serialize?: (value: T | null | undefined) => string | null;
+  set?: (elem: El, data: { name: string; newValue: T | null | undefined; oldValue: T | null | undefined; }) => void;
+}
+
+export var define: {
+  (name: string, ctor: Function): any;
+  (ctor: Function): any;
+};
+
+export interface EmitOptions {
+  bubbles?: boolean;
+  cancelable?: boolean;
+  composed?: boolean;
+  detail?: any;
+}
+export function emit(elem: EventTarget, name: string, opts?: EmitOptions): void;
+
+export var h: typeof vdom.element;
+
+export function link(elem: Component<any>, target?: string): (e: Event) => void;
+
+export var prop: {
+  create<T>(attr: PropOptions<any, T>): PropOptions<any, T> & ((attr: PropOptions<any, T>) => PropOptions<any, T>);
+
+  number(attr?: PropOptions<any, number>): PropOptions<any, number>;
+  boolean(attr?: PropOptions<any, boolean>): PropOptions<any, boolean>;
+  string(attr?: PropOptions<any, string>): PropOptions<any, string>;
+  array<T>(attr?: PropOptions<any, T[]>): PropOptions<any, T[]>;
+  object<T extends Object>(attr?: PropOptions<any, T>): PropOptions<any, T>;
+};
+
+export function props(elem: Component<any>, props?: any): void;
+
+export function ready(elem: Component<any>, done: (c: Component<any>) => void): void;
+
+// @DEPRECATED
+// export var symbols: any;
+
+
+//
+// VDOM Nodes
+// ----------------------------------------------------------------------
+
+export interface VDOMElement<P> {
+  type: VDOMElementType<P>;
+  props: P;
+  key: Key | null;
+}
+type VDOMText = string | number;
+type VDOMChild = VDOMElement<any> | VDOMText;
+
+// Should be Array<VDOMNode> but type aliases cannot be recursive
+type VDOMFragment = {} | Array<VDOMChild | any[] | boolean>;
+type VDOMNode = VDOMChild | VDOMFragment | boolean | null | undefined;
+
+type VDOMElementType<P> = string | { id: string } | ComponentClass<P> | SFC<P>;
+
+export var vdom: {
+
+  element<P>(type: VDOMElementType<P>, attrs?: HTMLProps<HTMLElement> | P, ...children: VDOMChild[]): VDOMElement<any>,
+  element<P>(type: VDOMElementType<P>, ...children: VDOMChild[]): VDOMElement<any>,
+
+  builder(): typeof vdom.element;
+  builder(...tags: string[]): ((attrs?: HTMLProps<HTMLElement>, ...children: VDOMChild[]) => VDOMElement<any>)[];
+
+  attr(...args: any[]): void;
+  elementClose: Function;
+  elementOpen: Function;
+  elementOpenEnd: Function;
+  elementOpenStart: Function;
+  elementVoid: Function;
+  text: Function;
+};

--- a/src/ts-typings/api.d.ts
+++ b/src/ts-typings/api.d.ts
@@ -1,6 +1,6 @@
-import {Key, HTMLProps} from './common';
+import { Key, HTMLProps } from './common';
 
-export type ComponentProps <El, T> = {
+export type ComponentProps<El, T> = {
   [P in keyof T]: PropOptions<El, T[P]>;
 };
 
@@ -57,7 +57,7 @@ type AttributeReflectionConfig = AttributeReflectionBaseType | {
   target?: AttributeReflectionBaseType
 }
 export interface PropOptions<El, T> {
-  attribute?: AttributeReflectionConfig ;
+  attribute?: AttributeReflectionConfig;
   coerce?: (value: any) => T | null | undefined;
   default?: T | null | undefined | ((elem: El, data: { name: string; }) => T | null | undefined);
   deserialize?: (value: string | null) => T | null | undefined;

--- a/src/ts-typings/common.d.ts
+++ b/src/ts-typings/common.d.ts
@@ -2,10 +2,12 @@ export type Key = string | number;
 export type Ref<T> = string | ((instance: T) => any);
 
 interface Attributes {
-  key?: Key;
+  key?: Key,
+  // this will be possible removed and added just to ClassAttributes because of https://github.com/skatejs/skatejs/issues/1020
+  slot?: string,
 }
 interface ClassAttributes<T> extends Attributes {
-  ref?: Ref<T>;
+  ref?: Ref<T>,
 }
 
 //

--- a/src/ts-typings/common.d.ts
+++ b/src/ts-typings/common.d.ts
@@ -1,0 +1,96 @@
+export type Key = string | number;
+export type Ref<T> = string | ((instance: T) => any);
+
+interface Attributes {
+  key?: Key;
+}
+interface ClassAttributes<T> extends Attributes {
+  ref?: Ref<T>;
+}
+
+//
+// JSX Related types
+// ----------------------------------------------------------------------
+
+export type HTMLProps<T extends Element> = Partial<T> & IncrementalHyperscriptAttributes<T>;
+export type IncrementalHyperscriptAttributes<T> = IncrementalDomHTMLAttributes<T> & HyperscriptHTMLAttributes & HyperscriptEventHandler<T>;
+
+interface IncrementalDomHTMLAttributes<T> {
+  key?: Key,
+  ref?: Ref<T>,
+  statics?: string[],
+  skip?: boolean,
+}
+interface HyperscriptHTMLAttributes {
+  class?: string,
+}
+
+interface HyperscriptEventHandler<T> {
+  onAbort?: typeof HTMLElement.prototype.onabort;
+  onActivate?: typeof HTMLElement.prototype.onactivate;
+  onBeforeactivate?: typeof HTMLElement.prototype.onbeforeactivate;
+  onBeforecopy?: typeof HTMLElement.prototype.onbeforecopy;
+  onBeforecut?: typeof HTMLElement.prototype.onbeforecut;
+  onBeforedeactivate?: typeof HTMLElement.prototype.onbeforedeactivate;
+  onBeforepaste?: typeof HTMLElement.prototype.onbeforepaste;
+  onBlur?: typeof HTMLElement.prototype.onblur;
+  onCanplay?: typeof HTMLElement.prototype.oncanplay;
+  onCanplaythrough?: typeof HTMLElement.prototype.oncanplaythrough;
+  onChange?: typeof HTMLElement.prototype.onchange;
+  onClick?: typeof HTMLElement.prototype.onclick;
+  onContextmenu?: typeof HTMLElement.prototype.oncontextmenu;
+  onCopy?: typeof HTMLElement.prototype.oncopy;
+  onCuechange?: typeof HTMLElement.prototype.oncuechange;
+  onCut?: typeof HTMLElement.prototype.oncut;
+  onDblclick?: typeof HTMLElement.prototype.ondblclick;
+  onDeactivate?: typeof HTMLElement.prototype.ondeactivate;
+  onDrag?: typeof HTMLElement.prototype.ondrag;
+  onDragend?: typeof HTMLElement.prototype.ondragend;
+  onDragenter?: typeof HTMLElement.prototype.ondragenter;
+  onDragleave?: typeof HTMLElement.prototype.ondragleave;
+  onDragover?: typeof HTMLElement.prototype.ondragover;
+  onDragstart?: typeof HTMLElement.prototype.ondragstart;
+  onDrop?: typeof HTMLElement.prototype.ondrop;
+  onDurationchange?: typeof HTMLElement.prototype.ondurationchange;
+  onEmptied?: typeof HTMLElement.prototype.onemptied;
+  onEnded?: typeof HTMLElement.prototype.onended;
+  onError?: typeof HTMLElement.prototype.onerror;
+  onFocus?: typeof HTMLElement.prototype.onfocus;
+  onInput?: typeof HTMLElement.prototype.oninput;
+  onInvalid?: typeof HTMLElement.prototype.oninvalid;
+  onKeydown?: typeof HTMLElement.prototype.onkeydown;
+  onKeypress?: typeof HTMLElement.prototype.onkeypress;
+  onKeyup?: typeof HTMLElement.prototype.onkeyup;
+  onLoad?: typeof HTMLElement.prototype.onload;
+  onLoadeddata?: typeof HTMLElement.prototype.onloadeddata;
+  onLoadedmetadata?: typeof HTMLElement.prototype.onloadedmetadata;
+  onLoadstart?: typeof HTMLElement.prototype.onloadstart;
+  onMousedown?: typeof HTMLElement.prototype.onmousedown;
+  onMouseenter?: typeof HTMLElement.prototype.onmouseenter;
+  onMouseleave?: typeof HTMLElement.prototype.onmouseleave;
+  onMousemove?: typeof HTMLElement.prototype.onmousemove;
+  onMouseout?: typeof HTMLElement.prototype.onmouseout;
+  onMouseover?: typeof HTMLElement.prototype.onmouseover;
+  onMouseup?: typeof HTMLElement.prototype.onmouseup;
+  onMousewheel?: typeof HTMLElement.prototype.onmousewheel;
+  onMscontentzoom?: typeof HTMLElement.prototype.onmscontentzoom;
+  onMsmanipulationstatechanged?: typeof HTMLElement.prototype.onmsmanipulationstatechanged;
+  onPaste?: typeof HTMLElement.prototype.onpaste;
+  onPause?: typeof HTMLElement.prototype.onpause;
+  onPlay?: typeof HTMLElement.prototype.onplay;
+  onPlaying?: typeof HTMLElement.prototype.onplaying;
+  onProgress?: typeof HTMLElement.prototype.onprogress;
+  onRatechange?: typeof HTMLElement.prototype.onratechange;
+  onReset?: typeof HTMLElement.prototype.onreset;
+  onScroll?: typeof HTMLElement.prototype.onscroll;
+  onSeeked?: typeof HTMLElement.prototype.onseeked;
+  onSeeking?: typeof HTMLElement.prototype.onseeking;
+  onSelect?: typeof HTMLElement.prototype.onselect;
+  onSelectstart?: typeof HTMLElement.prototype.onselectstart;
+  onStalled?: typeof HTMLElement.prototype.onstalled;
+  onSubmit?: typeof HTMLElement.prototype.onsubmit;
+  onSuspend?: typeof HTMLElement.prototype.onsuspend;
+  onTimeupdate?: typeof HTMLElement.prototype.ontimeupdate;
+  onVolumechange?: typeof HTMLElement.prototype.onvolumechange;
+  onWaiting?: typeof HTMLElement.prototype.onwaiting;
+}

--- a/src/ts-typings/jsx.d.ts
+++ b/src/ts-typings/jsx.d.ts
@@ -18,7 +18,9 @@ declare global {
     interface IntrinsicClassAttributes<T> extends ClassAttributes<T> { }
 
     interface IntrinsicElements {
-      a: HTMLProps<HTMLAnchorElement>;
+      // @FIXME replace with a: HTMLProps<HTMLAnchorElement> once https://github.com/Microsoft/TypeScript/issues/13345 is resolved
+      a: HTMLProps<HTMLAnchorElementFix>;
+
       abbr: HTMLProps<HTMLElement>;
       address: HTMLProps<HTMLElement>;
       area: HTMLProps<HTMLAreaElement>;
@@ -135,4 +137,38 @@ declare global {
       slot: HTMLProps<HTMLSlotElement>;
     }
   }
+}
+
+// @FIXME remove this once https://github.com/Microsoft/TypeScript/issues/13345 is resolved
+interface HTMLAnchorElementFix extends HTMLElement {
+  Methods: string;
+  charset: string;
+  coords: string;
+  download: string;
+  hash: string;
+  host: string;
+  hostname: string;
+  href: string;
+  hreflang: string;
+  readonly mimeType: string;
+  name: string;
+  readonly nameProp: string;
+  pathname: string;
+  port: string;
+  protocol: string;
+  readonly protocolLong: string;
+  rel: string;
+  rev: string;
+  search: string;
+  shape: string;
+  target: string;
+  text: string;
+  type: string;
+  urn: string;
+  addEventListener<K extends keyof HTMLElementEventMap>(
+    type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+    useCapture?: boolean): void;
+  addEventListener(
+    type: string, listener: EventListenerOrEventListenerObject,
+    useCapture?: boolean): void;
 }

--- a/src/ts-typings/jsx.d.ts
+++ b/src/ts-typings/jsx.d.ts
@@ -1,98 +1,12 @@
-import { VDOMElement } from './index'
+import { HTMLProps, Attributes, ClassAttributes } from './common';
+import { VDOMElement, Component } from './api';
 export { }
-
-export type Key = string | number;
-export type Ref<T> = string | ((instance: T) => any);
-
-export type HTMLProps<T extends Element> = Partial<T> & Attributes<T>;
-
-export type Attributes<T> = IncrementalDomHTMLAttributes<T> & HyperscriptHTMLAttributes & HyperscriptEventHandler<T>;
-interface IncrementalDomHTMLAttributes<T> {
-  key?: Key,
-  ref?: Ref<T>,
-  statics?: string[],
-  skip?: boolean,
-}
-interface HyperscriptHTMLAttributes {
-  class?: string,
-}
-
-interface HyperscriptEventHandler<T> {
-  onAbort?: typeof HTMLElement.prototype.onabort;
-  onActivate?: typeof HTMLElement.prototype.onactivate;
-  onBeforeactivate?: typeof HTMLElement.prototype.onbeforeactivate;
-  onBeforecopy?: typeof HTMLElement.prototype.onbeforecopy;
-  onBeforecut?: typeof HTMLElement.prototype.onbeforecut;
-  onBeforedeactivate?: typeof HTMLElement.prototype.onbeforedeactivate;
-  onBeforepaste?: typeof HTMLElement.prototype.onbeforepaste;
-  onBlur?: typeof HTMLElement.prototype.onblur;
-  onCanplay?: typeof HTMLElement.prototype.oncanplay;
-  onCanplaythrough?: typeof HTMLElement.prototype.oncanplaythrough;
-  onChange?: typeof HTMLElement.prototype.onchange;
-  onClick?: typeof HTMLElement.prototype.onclick;
-  onContextmenu?: typeof HTMLElement.prototype.oncontextmenu;
-  onCopy?: typeof HTMLElement.prototype.oncopy;
-  onCuechange?: typeof HTMLElement.prototype.oncuechange;
-  onCut?: typeof HTMLElement.prototype.oncut;
-  onDblclick?: typeof HTMLElement.prototype.ondblclick;
-  onDeactivate?: typeof HTMLElement.prototype.ondeactivate;
-  onDrag?: typeof HTMLElement.prototype.ondrag;
-  onDragend?: typeof HTMLElement.prototype.ondragend;
-  onDragenter?: typeof HTMLElement.prototype.ondragenter;
-  onDragleave?: typeof HTMLElement.prototype.ondragleave;
-  onDragover?: typeof HTMLElement.prototype.ondragover;
-  onDragstart?: typeof HTMLElement.prototype.ondragstart;
-  onDrop?: typeof HTMLElement.prototype.ondrop;
-  onDurationchange?: typeof HTMLElement.prototype.ondurationchange;
-  onEmptied?: typeof HTMLElement.prototype.onemptied;
-  onEnded?: typeof HTMLElement.prototype.onended;
-  onError?: typeof HTMLElement.prototype.onerror;
-  onFocus?: typeof HTMLElement.prototype.onfocus;
-  onInput?: typeof HTMLElement.prototype.oninput;
-  onInvalid?: typeof HTMLElement.prototype.oninvalid;
-  onKeydown?: typeof HTMLElement.prototype.onkeydown;
-  onKeypress?: typeof HTMLElement.prototype.onkeypress;
-  onKeyup?: typeof HTMLElement.prototype.onkeyup;
-  onLoad?: typeof HTMLElement.prototype.onload;
-  onLoadeddata?: typeof HTMLElement.prototype.onloadeddata;
-  onLoadedmetadata?: typeof HTMLElement.prototype.onloadedmetadata;
-  onLoadstart?: typeof HTMLElement.prototype.onloadstart;
-  onMousedown?: typeof HTMLElement.prototype.onmousedown;
-  onMouseenter?: typeof HTMLElement.prototype.onmouseenter;
-  onMouseleave?: typeof HTMLElement.prototype.onmouseleave;
-  onMousemove?: typeof HTMLElement.prototype.onmousemove;
-  onMouseout?: typeof HTMLElement.prototype.onmouseout;
-  onMouseover?: typeof HTMLElement.prototype.onmouseover;
-  onMouseup?: typeof HTMLElement.prototype.onmouseup;
-  onMousewheel?: typeof HTMLElement.prototype.onmousewheel;
-  onMscontentzoom?: typeof HTMLElement.prototype.onmscontentzoom;
-  onMsmanipulationstatechanged?: typeof HTMLElement.prototype.onmsmanipulationstatechanged;
-  onPaste?: typeof HTMLElement.prototype.onpaste;
-  onPause?: typeof HTMLElement.prototype.onpause;
-  onPlay?: typeof HTMLElement.prototype.onplay;
-  onPlaying?: typeof HTMLElement.prototype.onplaying;
-  onProgress?: typeof HTMLElement.prototype.onprogress;
-  onRatechange?: typeof HTMLElement.prototype.onratechange;
-  onReset?: typeof HTMLElement.prototype.onreset;
-  onScroll?: typeof HTMLElement.prototype.onscroll;
-  onSeeked?: typeof HTMLElement.prototype.onseeked;
-  onSeeking?: typeof HTMLElement.prototype.onseeking;
-  onSelect?: typeof HTMLElement.prototype.onselect;
-  onSelectstart?: typeof HTMLElement.prototype.onselectstart;
-  onStalled?: typeof HTMLElement.prototype.onstalled;
-  onSubmit?: typeof HTMLElement.prototype.onsubmit;
-  onSuspend?: typeof HTMLElement.prototype.onsuspend;
-  onTimeupdate?: typeof HTMLElement.prototype.ontimeupdate;
-  onVolumechange?: typeof HTMLElement.prototype.onvolumechange;
-  onWaiting?: typeof HTMLElement.prototype.onwaiting;
-}
 
 declare global {
   // https://www.typescriptlang.org/docs/handbook/jsx.html
   namespace JSX {
-    interface ElementClass {
-    }
-
+    interface Element extends VDOMElement<any> { }
+    interface ElementClass extends Component<any> {}
     interface ElementAttributesProperty<Props> {
       // Special hack for own components type checking.
       // more detail, see: https://www.typescriptlang.org/docs/handbook/jsx.html
@@ -100,8 +14,8 @@ declare global {
       readonly _props: Props,
     }
 
-    interface Element extends VDOMElement<any> {
-    }
+    interface IntrinsicAttributes extends Attributes { }
+    interface IntrinsicClassAttributes<T> extends ClassAttributes<T> { }
 
     interface IntrinsicElements {
       a: HTMLProps<HTMLAnchorElement>;

--- a/src/ts-typings/jsx.d.ts
+++ b/src/ts-typings/jsx.d.ts
@@ -6,7 +6,7 @@ declare global {
   // https://www.typescriptlang.org/docs/handbook/jsx.html
   namespace JSX {
     interface Element extends VDOMElement<any> { }
-    interface ElementClass extends Component<any> {}
+    interface ElementClass extends Component<any> { }
     interface ElementAttributesProperty<Props> {
       // Special hack for own components type checking.
       // more detail, see: https://www.typescriptlang.org/docs/handbook/jsx.html

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -670,4 +670,13 @@
       }
     }
   }
+  {
+    skate.h('div', { class:'c-button c-button--block' });
+
+    class TestCmp extends skate.Component<any> {
+      renderCallback() {
+        return <div class='c-button c-button--block'></div>
+      }
+    }
+  }
 }

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -671,7 +671,7 @@
     }
   }
   {
-    skate.h('div', { class:'c-button c-button--block' });
+    skate.h('div', { class: 'c-button c-button--block' });
 
     class TestCmp extends skate.Component<any> {
       renderCallback() {

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -684,4 +684,57 @@
     const Link: skate.SFC<{ to: string }> = ({to}) => <a href={to}><slot /></a>;
     const LinkH: skate.SFC<{ to: string }> = ({to}) => skate.h('a', { href: to }, skate.h('slot'));
   }
+  // slot projection attributes on Component references via JSX
+  {
+    const Header = () => (<span>Hello</span>)
+    const Body = () => (<span>Hey yo body!</span>)
+    const Footer = () => (<span>Footer baby</span>)
+
+    class Menu extends skate.Component<void>{
+      private menu = [{ link: 'home', name: 'Home' }, { link: 'about', name: 'About' }];
+      renderCallback() {
+        return (
+          <ul>
+            {this.menu.map((menuItem) => <li><a href={menuItem.link}>{menuItem.name}</a></li>)}
+          </ul>
+        )
+      }
+    }
+    class Page extends skate.Component<void> {
+      static get is() { return 'my-page' }
+      static get slots() {
+        return {
+          header: 'header',
+          body: 'body',
+          footer: 'footer',
+          menu: 'menu'
+        }
+      }
+      renderCallback() {
+        return (
+          <main>
+            <header><slot name={Page.slots.header} /></header>
+            <nav><slot name="menu" /></nav>
+            <section><slot name={Page.slots.body} /></section>
+            <footer><slot name="footer" /></footer>
+          </main>
+        )
+      }
+    }
+
+    class App extends skate.Component<void> {
+      renderCallback() {
+        return (
+          <Page>
+            <Menu slot={Page.slots.menu} ref={_e => console.log(_e)} />
+            {/* this projection doesn't work in actual code https://github.com/skatejs/skatejs/issues/1020 */}
+            <Header slot={Page.slots.header} />
+            <Body slot={Page.slots.body} />
+            <Footer slot="footer" />
+          </Page>
+        );
+      }
+    }
+
+  }
 }

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -656,7 +656,7 @@
         return <div
           ref={(e: HTMLElement) => (e.innerHTML = '<p>oh no you didn\'t</p>')}
           skip
-          ></div>
+        ></div>
       }
     }
 

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -543,7 +543,7 @@
   skate.vdom.elementOpen(MyElement);
 
   // for https://github.com/Microsoft/TypeScript/issues/7004
-  const anyProps: any = {};
+  const anyProps = {};
   <MyElement {...anyProps} />;
 }
 { // https://github.com/skatejs/skatejs#function-helper
@@ -678,5 +678,10 @@
         return <div class='c-button c-button--block'></div>
       }
     }
+  }
+  // anchor test so this https://github.com/Microsoft/TypeScript/issues/13345 is mitigated
+  {
+    const Link: skate.SFC<{ to: string }> = ({to}) => <a href={to}><slot /></a>;
+    const LinkH: skate.SFC<{ to: string }> = ({to}) => skate.h('a', { href: to }, skate.h('slot'));
   }
 }

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -370,23 +370,25 @@
         value: { attribute: true }
       };
     }
-    renderCallback() {
-      skate.h('input', { name: 'someValue', onChange: skate.link(this), type: 'text' });
+    renderCallback(): any {
+      const linkedInput = skate.h('input', { name: 'someValue', onChange: skate.link(this), type: 'text' });
 
-      skate.link(this, 'someValue');
+      const explicitlySetLinkedProp = skate.link(this, 'someValue');
 
-      skate.link(this, 'obj.someValue');
+      const explicitlySetLinkedPropPath = skate.link(this, 'obj.someValue');
 
-      skate.h('input', { name: 'someValue', onChange: skate.link(this, 'obj.'), type: 'text' });
-
+      const explicitlySetLinkedInputPathWithCustomPropName = skate.h('input', { name: 'someValue', onChange: skate.link(this, 'obj.'), type: 'text' });
       const linkage = skate.link(this, 'obj.');
-      skate.h('input', { name: 'someValue1', onChange: linkage, type: 'text' });
-      skate.h('input', { name: 'someValue2', onChange: linkage, type: 'checkbox' });
-      skate.h('input', { name: 'someValue3', onChange: linkage, type: 'radio' });
-      skate.h('select', { name: 'someValue4', onChange: linkage },
-        skate.h('option', { value: 2 }, 'Option 2'),
-        skate.h('option', { value: 1 }, 'Option 1'),
-      );
+
+      return [
+        skate.h('input', { name: 'someValue1', onChange: linkage, type: 'text' }),
+        skate.h('input', { name: 'someValue2', onChange: linkage, type: 'checkbox' }),
+        skate.h('input', { name: 'someValue3', onChange: linkage, type: 'radio' }),
+        skate.h('select', { name: 'someValue4', onChange: linkage },
+          skate.h('option', { value: 2 }, 'Option 2'),
+          skate.h('option', { value: 1 }, 'Option 1'),
+        )
+      ];
     }
   });
 }
@@ -552,22 +554,22 @@
     skate.h(MyElement);
   }
   {
-    const MyElement = (props: any) => skate.h('div', `Hello, ${props.name}!`);
+    const MyElement = (props: { name: string }) => skate.h('div', `Hello, ${props.name}!`);
 
     // Renders <div>Hello, Bob!</div>
     skate.h(MyElement, { name: 'Bob' });
   }
   {
-    const MyElement = (props: any, chren: any) => skate.h('div', 'Hello, ', chren, '!');
+    const MyElement = (props: void, children: string) => skate.h('div', 'Hello, ', children, '!');
 
     // Renders <div>Hello, Mary!</div>
     skate.h(MyElement, 'Mary');
   }
   {
-    const MyElement = (props: any, chren: any) => <div>Hello, {chren}!</div>;
+    const MyElement = (props: any, children: Node) => <div>Hello, {children}!</div>;
 
     // Renders <div>Hello, Mary!</div>
-    <MyElement>Mary</MyElement>
+    <MyElement>123</MyElement>
   }
 }
 { // https://github.com/skatejs/skatejs#special-attributes
@@ -576,6 +578,14 @@
       skate.h('li', { key: 0 }),
       skate.h('li', { key: 1 }),
     );
+
+    const ArrayCmp = () => (
+      <ul>
+        <li key={0}></li>
+        <li key={1}></li>
+      </ul>
+    );
+
   }
 
   {
@@ -584,6 +594,13 @@
     skate.h('button', { 'on-click': onClick });
 
     skate.h('button', { onclick: onClick });
+
+    const TestCmp = () => (
+      <div>
+        <button onclick={onClick}></button>
+        <button onClick={onClick}></button>
+      </div>
+    );
   }
 
   {
@@ -604,6 +621,10 @@
   {
     const ref = (button: HTMLButtonElement) => button.addEventListener('click', console.log);
     skate.h('button', { ref });
+
+    const TestCmp = () => (
+      <button ref={ref}></button>
+    );
   }
   {
     const ref = console.log;
@@ -612,6 +633,12 @@
         return skate.h('div', { ref });
       }
     });
+
+    class TestCmp extends skate.Component<any> {
+      renderCallback() {
+        return <div ref={ref}></div>
+      }
+    }
   }
   {
     customElements.define('my-element', class extends skate.Component<any> {
@@ -623,8 +650,24 @@
   }
   {
     skate.h('div', { ref: (e: HTMLElement) => (e.innerHTML = '<p>oh no you didn\'t</p>'), skip: true });
+
+    class TestCmp extends skate.Component<any> {
+      renderCallback() {
+        return <div
+          ref={(e: HTMLElement) => (e.innerHTML = '<p>oh no you didn\'t</p>')}
+          skip
+          ></div>
+      }
+    }
+
   }
   {
     skate.h('div', { statics: ['attr1', 'prop2'] });
+
+    class TestCmp extends skate.Component<any> {
+      renderCallback() {
+        return <div statics={['attr1', 'prop2']}></div>
+      }
+    }
   }
 }

--- a/test/definitions/sample-component.tsx
+++ b/test/definitions/sample-component.tsx
@@ -1,5 +1,6 @@
 import * as skate from "skatejs";
 
+// @TODO this override is needed because of https://github.com/Microsoft/TypeScript/pull/12488 will be fixed in TS 2.2
 (window as any).__extends = function(d: any, b: any) {
   Object.setPrototypeOf(d, b);
   var __: any = function() { this.constructor = d; }
@@ -11,6 +12,7 @@ interface CountUpProps {
 }
 
 class CountUpComponent extends skate.Component<CountUpProps> {
+  static get is() { return 'x-countup' }
   static get props(): skate.ComponentProps<CountUpComponent, CountUpProps> {
     return {
       count: skate.prop.number({
@@ -31,13 +33,13 @@ class CountUpComponent extends skate.Component<CountUpProps> {
   renderCallback(): any {
     return (
       <div>
-        <p>Count: <span>{this.count}</span></p>
-        <button onClick={e => this.click()}>Count up</button>
+        <CounterOutput count={this.count} />
+        <Button onClick={e => this.click()}>Count up</Button>
       </div>
     );
   }
 }
-customElements.define("x-countup", CountUpComponent);
+customElements.define(CountUpComponent.is, CountUpComponent);
 
 customElements.define("x-app", class extends skate.Component<{}> {
   renderCallback() {
@@ -49,3 +51,14 @@ customElements.define("x-app", class extends skate.Component<{}> {
     );
   }
 });
+
+
+type ButtonProps = { onClick: (e: MouseEvent) => void };
+const Button: skate.SFC<ButtonProps> = ({onClick}, children: any) => (
+  <button onClick={onClick}>{children}</button>
+);
+
+type CounterOutputProps = { count: number };
+const CounterOutput: skate.SFC<CounterOutputProps> = (props) => (
+  <p>Count: <span>{props.count}</span></p>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
   },
   "include": [
     "index.d.ts",
-    "jsx.d.ts",
     "test/definitions/**/*.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "pretty": true
   },
   "include": [
-    "index.d.ts",
+    "src/index.d.ts",
+    "src/ts-typings/*",
     "test/definitions/**/*.tsx"
   ]
 }


### PR DESCRIPTION
Closes #1010 

- also adds proper type checking and intelisense for Stateless Components 🍺 

TODO: 
- [x] extract common types which should be private ( for instance consumer shouldn't be able to import `VDOMElement` from 'skatejs' )