### PR TITLE
Fix global

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "build:global": "skate",
+  "global": "skate",
   "name": "skatejs",
   "description": "Skate is a library built on top of the W3C web component specs that enables you to write functional and performant web components with a very small footprint.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,14 @@
 {
   "global": "skate",
+  "externals": {
+    "incremental-dom": {
+      "amd": "incremental-dom",
+      "commonjs": "incremental-dom",
+      "commonjs2": "incremental-dom",
+      "root": "IncrementalDOM"
+    }
+  },
+
   "name": "skatejs",
   "description": "Skate is a library built on top of the W3C web component specs that enables you to write functional and performant web components with a very small footprint.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "src"
   ],
   "dependencies": {
-    "incremental-dom": "0.4.1",
-    "window-or-global": "1.0.1"
+    "incremental-dom": "0.4.1"
   },
   "devDependencies": {
     "@webpack-blocks/babel6": "^0.3.0",

--- a/src/api/component.js
+++ b/src/api/component.js
@@ -24,7 +24,7 @@ import { createNativePropertyDescriptor } from '../lifecycle/props-init';
 import { isFunction } from '../util/is-type';
 import objectIs from '../polyfills/object-is';
 import setCtorNativeProperty from '../util/set-ctor-native-property';
-import root from 'window-or-global';
+import root from '../util/root';
 
 const HTMLElement = root.HTMLElement || class {};
 const _prevName = createSymbol('prevName');

--- a/src/api/define.js
+++ b/src/api/define.js
@@ -1,6 +1,6 @@
 import Component from './component';
 import uniqueId from '../util/unique-id';
-import root from 'window-or-global';
+import root from '../util/root';
 
 export default function (...args) {
   const { customElements, HTMLElement } = root;

--- a/src/api/emit.js
+++ b/src/api/emit.js
@@ -1,4 +1,4 @@
-import root from 'window-or-global';
+import root from '../util/root';
 
 const Event = ((TheEvent) => {
   if (TheEvent) {

--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -11,7 +11,7 @@ import {
 } from 'incremental-dom';
 import { name as $name, ref as $ref } from '../util/symbols';
 import propContext from '../util/prop-context';
-import root from 'window-or-global';
+import root from '../util/root';
 
 const { customElements, HTMLElement } = root;
 const applyDefault = attributes[symbols.default];

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -1,5 +1,5 @@
 import native from './native';
-import root from 'window-or-global';
+import root from './root';
 
 const { MutationObserver } = root;
 

--- a/src/util/root.js
+++ b/src/util/root.js
@@ -1,0 +1,1 @@
+export default typeof window === 'undefined' ? global : window;

--- a/webpack-blocks.js
+++ b/webpack-blocks.js
@@ -30,11 +30,12 @@ function externals () {
   const {
     dependencies,
     devDependencies,
+    externals,
     optionalDependencies,
     peerDependencies
   } = pack();
   return () => ({
-    externals: Object.keys(
+    externals: externals || Object.keys(
       Object.assign(
         {},
         dependencies,

--- a/webpack-blocks.js
+++ b/webpack-blocks.js
@@ -47,10 +47,10 @@ function externals () {
 }
 
 function output (userDefinedOutput) {
-  const { name } = pack();
+  const { global, name } = pack();
   const temp = Object.assign({}, {
     filename: '[name]',
-    library: name,
+    library: global || name,
     libraryTarget: 'umd',
     path: './',
     sourceMapFilename: '[file].map'


### PR DESCRIPTION
Looks like the Webpack 2 refactor broke the global name for `incremental-dom` (`IncrementalDOM`). The `window-or-global` package also doesn't export a global it seems, so I just refactored that out and created a smaller util for it. @Hotell should be happy about that :p