### PR TITLE
fix(ts-typings): add proper emit,props defs and make SFC not allow ref and slot props by default 

### DIFF
--- a/src/ts-typings/api.d.ts
+++ b/src/ts-typings/api.d.ts
@@ -99,7 +99,14 @@ export var prop: {
   object<T extends Object>(attr?: PropOptions<any, T>): PropOptions<any, T>;
 };
 
-export function props(elem: Component<any>, props?: any): void;
+/**
+ * The props function is a getter or setter depending on if you specify the second argument.
+ * If you do not provide props, then the current state of the component is returned.
+ * If you pass props, then the current state of the component is set.
+ * When you set state, the component will re-render synchronously only if it needs to be re-rendered.
+ */
+export function props<P>(elem: Component<P>): P;
+export function props<P>(elem: Component<P>, props: Pick<Component<P>, '_props'>['_props']): void;
 
 export function ready(elem: Component<any>, done: (c: Component<any>) => void): void;
 

--- a/src/ts-typings/api.d.ts
+++ b/src/ts-typings/api.d.ts
@@ -78,7 +78,12 @@ export interface EmitOptions {
   composed?: boolean;
   detail?: any;
 }
-export function emit(elem: EventTarget, name: string, opts?: EmitOptions): void;
+
+/**
+ * Emits an Event on elem that is composed, bubbles and is cancelable by default.
+ * The return value of emit() is the same as dispatchEvent().
+ */
+export function emit(elem: EventTarget, eventName: string, eventOptions?: EmitOptions): boolean;
 
 export var h: typeof vdom.element;
 

--- a/src/ts-typings/common.d.ts
+++ b/src/ts-typings/common.d.ts
@@ -1,13 +1,12 @@
 export type Key = string | number;
-export type Ref<T> = string | ((instance: T) => any);
+export type Ref<T> = ((instance: T) => any);
 
 interface Attributes {
   key?: Key,
-  // this will be possible removed and added just to ClassAttributes because of https://github.com/skatejs/skatejs/issues/1020
-  slot?: string,
 }
 interface ClassAttributes<T> extends Attributes {
   ref?: Ref<T>,
+  slot?: string,
 }
 
 //

--- a/src/ts-typings/common.d.ts
+++ b/src/ts-typings/common.d.ts
@@ -24,6 +24,7 @@ interface IncrementalDomHTMLAttributes<T> {
 }
 interface HyperscriptHTMLAttributes {
   class?: string,
+  role?: string,
 }
 
 interface HyperscriptEventHandler<T> {

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -392,7 +392,11 @@
     }
   });
 }
-{ // https://skatejs.gitbooks.io/skatejs/content/docs/api/#prop
+
+// #prop
+// @link https://skatejs.gitbooks.io/skatejs/content/docs/api/prop.html
+// ====================================================================
+{
   const myNewProp = skate.prop.create({});
   myNewProp({});
 
@@ -456,29 +460,40 @@
     }
   }
 }
-{ // https://github.com/skatejs/skatejs#props-elem-props
+
+// #props
+// @link https://skatejs.gitbooks.io/skatejs/content/docs/api/props.html
+// ====================================================================
+{
   const { define, props } = skate;
 
-  class Elem extends skate.Component<any> {
+  class Elem extends skate.Component<{ prop1?: string }> {
     static get props() {
       return {
         prop1: {}
       };
     }
+    prop1: string;
+    prop2: string;
   }
   customElements.define('my-element', Elem);
   const elem = new Elem();
 
+  elem.prop2 = 'value 2';
   // Set any property you want.
   props(elem, {
     prop1: 'value 1',
-    prop2: 'value 2'
+    // in TS we wanna be explicit and set only "state" props which will trigger render,
+    // so if you wanna set private props, update them via this.yourProp = newValue
+    // - following line works just fine in plain JS but it's considered a mistake, TS will explicitly tell us that we are doing something wrong
+    // prop2: 'value 2'
   });
 
   // Only returns props you've defined on your component.
   // { prop1: 'value 1' }
   props(elem);
 }
+
 { // https://github.com/skatejs/skatejs#ready-element-callback
   // NONE
 }

--- a/test/definitions/misc.tsx
+++ b/test/definitions/misc.tsx
@@ -686,9 +686,10 @@
   }
   // slot projection attributes on Component references via JSX
   {
-    const Header = () => (<span>Hello</span>)
-    const Body = () => (<span>Hey yo body!</span>)
-    const Footer = () => (<span>Footer baby</span>)
+    type SFCSlotRef<E extends HTMLElement> = skate.SFC<{ slot?: string, ref?: ((instance: E) => any) }>;
+    const Header: SFCSlotRef<HTMLSpanElement> = (props) => (<span {...props}>Hello</span>)
+    const Body: SFCSlotRef<HTMLSpanElement> = (props) => (<span {...props}>Hey yo body!</span>)
+    const Footer: SFCSlotRef<HTMLSpanElement> = (props) => (<span {...props}>Footer baby</span>)
 
     class Menu extends skate.Component<void>{
       private menu = [{ link: 'home', name: 'Home' }, { link: 'about', name: 'About' }];
@@ -727,10 +728,12 @@
         return (
           <Page>
             <Menu slot={Page.slots.menu} ref={_e => console.log(_e)} />
-            {/* this projection doesn't work in actual code https://github.com/skatejs/skatejs/issues/1020 */}
+
+            {/* projection and refs doesn't work by default, because you cant ref,slot a function. Instead you need to manually propagate props */}
             <Header slot={Page.slots.header} />
             <Body slot={Page.slots.body} />
-            <Footer slot="footer" />
+            <Footer slot="footer" ref={_e => console.log(_e)} />
+
           </Page>
         );
       }


### PR DESCRIPTION
What this PR does:
- as discussed within #1020 SFC don't support ref and slot by default. So this is addressed within this fix
- adds proper type annotations to `emit`
![skate-ts-emit-annotated](https://cloud.githubusercontent.com/assets/1223799/22119759/1c2f2cbc-de7d-11e6-9628-8f66c7dd1d0e.gif)

- adds proper type annotations to `props`
![skate-ts-props-annotated](https://cloud.githubusercontent.com/assets/1223799/22119700/dbbe780e-de7c-11e6-96f3-330ae206b0a0.gif)

- adds missing `role` attribute