### PR TITLE
vdom symbols exported

### DIFF
--- a/src/api/vdom.js
+++ b/src/api/vdom.js
@@ -9,7 +9,13 @@ import {
   symbols,
   text
 } from 'incremental-dom';
-import { name as $name, ref as $ref } from '../util/symbols';
+import {
+    name as $name,
+    ref as $ref,
+    skip as $skip,
+    currentEventHandlers as $currentEventHandlers,
+    stackCurrentHelperProps as $stackCurrentHelperProps,
+} from '../util/symbols';
 import propContext from '../util/prop-context';
 import root from '../util/root';
 
@@ -19,10 +25,6 @@ const applyDefault = attributes[symbols.default];
 // A stack of children that corresponds to the current function helper being
 // executed.
 const stackChren = [];
-
-const $skip = '__skip';
-const $currentEventHandlers = '__events';
-const $stackCurrentHelperProps = '__props';
 
 // The current function helper in the stack.
 let stackCurrentHelper;

--- a/src/util/symbols.js
+++ b/src/util/symbols.js
@@ -14,6 +14,7 @@ export const ctorCreateInitProps = '____skate_ctor_createInitProps';
 export const ctorObservedAttributes = '____skate_ctor_observedAttributes';
 export const ctorProps = '____skate_ctor_props';
 export const ctorPropsMap = '____skate_ctor_propsMap';
+export const stackCurrentHelperProps = '__props';
 
 // Used on the Element
 export const props = '____skate_props';
@@ -22,3 +23,5 @@ export const renderer = '____skate_renderer';
 export const rendering = '____skate_rendering';
 export const rendererDebounced = '____skate_rendererDebounced';
 export const updated = '____skate_updated';
+export const skip = '__skip';
+export const currentEventHandlers = '__events';


### PR DESCRIPTION
It seems that some symbols are deprecated from the source comments. I needed to programatically set skip, but the skip symbol isn't in symbols.js

I assume that it should be along with the others.