### PR TITLE
Fixed multiple definition of properties on the same constructor.

### DIFF
--- a/src/util/with-props.js
+++ b/src/util/with-props.js
@@ -8,9 +8,10 @@ const _syncingPropertyToAttribute = sym('_syncingPropertyToAttribute');
 export const _updateDebounced = sym('_updateDebounced');
 
 export function defineProps (Ctor) {
-  if (!Ctor[_definedProps]) {
-    Ctor[_definedProps] = true;
+  if (Ctor[_definedProps]) {
+    return;
   }
+  Ctor[_definedProps] = true;
 
   const { prototype } = Ctor;
   const props = normPropDefs(Ctor);

--- a/test/unit/props.spec.js
+++ b/test/unit/props.spec.js
@@ -9,9 +9,10 @@ import { define, withProps, withUnique } from 'src';
 
 describe('api/props', () => {
   let elem;
+  let ElemClass;
 
   beforeEach(done => {
-    elem = new (define(class extends withUnique(withProps()) {
+    ElemClass = define(class extends withUnique(withProps()) {
       static get props () {
         return {
           prop1: null,
@@ -28,7 +29,8 @@ describe('api/props', () => {
       propsSetCallback () {
         this._rendered++;
       }
-    }))();
+    });
+    elem = new ElemClass();
     fixture(elem);
     afterMutations(done);
   });
@@ -41,6 +43,19 @@ describe('api/props', () => {
       expect(curr.prop2).toEqual('test2');
       expect('prop3' in curr).toEqual(true);
       expect(curr.undeclaredProp).toEqual(undefined);
+    });
+
+    it('should work the same when the class is instantiated twice', () => {
+      let elem2 = new ElemClass();
+
+      const curr = elem.props;
+
+      expect(curr.prop1).toEqual('test1');
+      expect(curr.prop2).toEqual('test2');
+      expect('prop3' in curr).toEqual(true);
+      expect(curr.undeclaredProp).toEqual(undefined);
+
+      expect(elem2.props.prop1).toEqual(curr.prop1, 'compare value on both instances');
     });
   });
 });


### PR DESCRIPTION
fixes #1111 

Properties were defined at each instantiation of a given element. These caused the backing symbol to be changed for each instance but as the properties are defined on the prototype, this meant that all instances apart from the last actually lost track of the props value.

This was visible in usage when instantiating the same component multiple times in a page at the same time (with innerHTML for example). Only the last one actually got access to the props when render time comes (after debounce).