### PR TITLE
1. Streamline render

### DIFF
--- a/src/with-component.js
+++ b/src/with-component.js
@@ -6,9 +6,8 @@ import { withRender } from './with-render';
 import { withUnique } from './with-unique';
 
 export const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
-  propsChangedCallback (next, prev) {
-    super.propsChangedCallback(next, prev);
-    this.rendererCallback(render);
+  rendererCallback (shadowRoot, renderCallback) {
+    render(renderCallback(), shadowRoot);
   }
 };
 

--- a/src/with-render.js
+++ b/src/with-render.js
@@ -1,18 +1,18 @@
 import { HTMLElement } from './util';
 
 export const withRender = (Base = HTMLElement) => class extends Base {
+  propsUpdatedCallback (next, prev) {
+    super.propsUpdatedCallback(next, prev);
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: 'open' });
+    }
+    this.rendererCallback(this.shadowRoot, () => this.renderCallback(next));
+    this.renderedCallback();
+  }
+
   // Called to render the component.
   renderCallback () {}
 
   // Called after the component has rendered.
   renderedCallback () {}
-
-  // Called to render the component.
-  rendererCallback (render) {
-    if (!this.shadowRoot) {
-      this.attachShadow({ mode: 'open' });
-    }
-    render(this.renderCallback(this), this.shadowRoot);
-    this.renderedCallback();
-  }
 };

--- a/src/with-render.js
+++ b/src/with-render.js
@@ -6,7 +6,7 @@ export const withRender = (Base = HTMLElement) => class extends Base {
     if (!this.shadowRoot) {
       this.attachShadow({ mode: 'open' });
     }
-    this.rendererCallback(this.shadowRoot, () => this.renderCallback(next));
+    this.rendererCallback(this.shadowRoot, () => this.renderCallback(this));
     this.renderedCallback();
   }
 

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -44,13 +44,14 @@ describe('withRender', () => {
       );
     });
 
-    it('should pass in the props as the only argument', done => {
+    it('should pass in the element as the only argument', done => {
       const Elem = define(class extends Component {
         static props = {
           test: null
         }
-        renderCallback ({ test, ...rest }) {
-          expect(Object.keys(rest).length).toBe(0);
+        renderCallback (elem) {
+          const { test } = elem.props;
+          expect(this).toBe(elem);
           return h('div', null, test);
         }
       });

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -46,21 +46,16 @@ describe('withRender', () => {
 
     it('should pass in the element as the only argument', done => {
       const Elem = define(class extends Component {
-        static props = {
-          test: null
-        }
         renderCallback (elem) {
-          const { test } = elem.props;
           expect(this).toBe(elem);
-          return h('div', null, test);
+          return h('div', null, 'called');
         }
       });
 
       const elem = new Elem();
-      elem.test = 'testing';
       fixture(elem);
       afterMutations(
-        () => expect(elem.shadowRoot.firstChild.textContent).toBe('testing'),
+        () => expect(elem.shadowRoot.firstChild.textContent).toBe('called'),
         done
       );
     });

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -7,7 +7,7 @@ import { Component, define, h } from 'src';
 import afterMutations from '../lib/after-mutations';
 import fixture from '../lib/fixture';
 
-describe('Mixins.Render', () => {
+describe('withRender', () => {
   describe('renderCallback()', () => {
     it('should be called', done => {
       const Elem = define(class extends Component {
@@ -18,9 +18,7 @@ describe('Mixins.Render', () => {
 
       const elem = new Elem();
       fixture(elem);
-      afterMutations(
-        done
-      );
+      afterMutations(done);
     });
 
     it('should get called before descendants are initialised', done => {
@@ -46,17 +44,22 @@ describe('Mixins.Render', () => {
       );
     });
 
-    it('should pass in the element as the only argument', done => {
+    it('should pass in the props as the only argument', done => {
       const Elem = define(class extends Component {
-        renderCallback ({ localName }) {
-          return h('div', null, localName);
+        static props = {
+          test: null
+        }
+        renderCallback ({ test, ...rest }) {
+          expect(Object.keys(rest).length).toBe(0);
+          return h('div', null, test);
         }
       });
 
       const elem = new Elem();
+      elem.test = 'testing';
       fixture(elem);
       afterMutations(
-        () => expect(elem.shadowRoot.firstChild.textContent).toBe(Elem.is),
+        () => expect(elem.shadowRoot.firstChild.textContent).toBe('testing'),
         done
       );
     });


### PR DESCRIPTION
The goal of this is to make the renderer API as simple as possible, but also as extensible as possible for consumers when extending `withRender()`. Edge cases can just extend `withProps()` and use `propsUpdatedCallback()`.