### PR TITLE
Correct link in documentation

### DIFF
--- a/docs/recipes/design-patterns/component-composition.md
+++ b/docs/recipes/design-patterns/component-composition.md
@@ -62,7 +62,7 @@ class Button extends Colors {
 
 ## Mixins
 
-> Learn more at [real-mixins-with-javascript-classes](justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/)
+> Learn more at [real-mixins-with-javascript-classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/)
 
 ```js
 import { Component, h } from 'skatejs';


### PR DESCRIPTION
Add missing `http://` to link to the article "'Real' Mixins with JavaScript Classes"