### PR TITLE
Call renderer when props change

### DIFF
--- a/src/with-component.js
+++ b/src/with-component.js
@@ -1,4 +1,4 @@
-import { h, render as preactRender } from 'preact';
+import { h, render } from 'preact';
 
 import { HTMLElement, sym } from './util';
 import { withProps } from './with-props';
@@ -7,16 +7,12 @@ import { withUnique } from './with-unique';
 
 const _preactDom = sym('_preactDom');
 
-function render (vnode, root) {
-  const dom = preactRender(vnode, root, this[_preactDom]);
-  if (!this[_preactDom]) {
-    this[_preactDom] = dom;
-  }
-}
-
 export const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
   rendererCallback (shadowRoot, renderCallback) {
-    render.call(this, renderCallback(), shadowRoot);
+    const dom = render(renderCallback(), shadowRoot, this[_preactDom]);
+    if (!this[_preactDom]) {
+      this[_preactDom] = dom;
+    }
   }
 };
 

--- a/src/with-component.js
+++ b/src/with-component.js
@@ -1,13 +1,22 @@
-import { h, render } from 'preact';
+import { h, render as preactRender } from 'preact';
 
-import { HTMLElement } from './util';
+import { HTMLElement, sym } from './util';
 import { withProps } from './with-props';
 import { withRender } from './with-render';
 import { withUnique } from './with-unique';
 
+const _preactDom = sym('_preactDom');
+
+function render (vnode, root) {
+  const dom = preactRender(vnode, root, this[_preactDom]);
+  if (!this[_preactDom]) {
+    this[_preactDom] = dom;
+  }
+}
+
 export const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
   rendererCallback (shadowRoot, renderCallback) {
-    render(renderCallback(), shadowRoot);
+    render.call(this, renderCallback(), shadowRoot);
   }
 };
 

--- a/src/with-component.js
+++ b/src/with-component.js
@@ -9,10 +9,7 @@ const _preactDom = sym('_preactDom');
 
 export const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
   rendererCallback (shadowRoot, renderCallback) {
-    const dom = render(renderCallback(), shadowRoot, this[_preactDom]);
-    if (!this[_preactDom]) {
-      this[_preactDom] = dom;
-    }
+    this[_preactDom] = render(renderCallback(), shadowRoot, this[_preactDom]);
   }
 };
 

--- a/src/with-props.js
+++ b/src/with-props.js
@@ -89,7 +89,7 @@ export const withProps = (Base = HTMLElement) => class extends Base {
 
   // Called to see if the props changed.
   propsUpdatedCallback (next, prev) {
-    return !prev || keys(prev).every(k => prev[k] === next[k]);
+    return !prev || keys(prev).some(k => prev[k] !== next[k]);
   }
 
   attributeChangedCallback (name, oldValue, newValue) {

--- a/src/with-render.js
+++ b/src/with-render.js
@@ -9,8 +9,7 @@ function attachShadow (elem) {
 }
 
 export const withRender = (Base = HTMLElement) => class extends Base {
-  propsUpdatedCallback (next, prev) {
-    super.propsUpdatedCallback(next, prev);
+  propsChangedCallback () {
     this[_shadowRoot] = this[_shadowRoot] || (this[_shadowRoot] = attachShadow(this));
     this.rendererCallback(this[_shadowRoot], () => this.renderCallback(this));
     this.renderedCallback();

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -93,6 +93,42 @@ describe('withRender', () => {
       fixture(elem);
       afterMutations(done);
     });
+
+    it('should be called if props change', (done) => {
+      const Elem = define(class extends Component {
+        static get props () {
+          return {
+            foo: {default: 'bar'}
+          };
+        }
+
+        constructor () {
+          super();
+          this.count = 0;
+        }
+
+        renderCallback () {
+          return vdom('div', null, this.foo);
+        }
+
+        renderedCallback () {
+          this.count++;
+
+          if (this.count === 1) {
+            expect(this.shadowRoot.firstChild.textContent).toBe('bar');
+          } else if (this.count === 2) {
+            expect(this.shadowRoot.firstChild.textContent).toBe('baz');
+            done();
+          }
+        }
+      });
+
+      const elem = new Elem();
+      fixture(elem);
+      afterMutations(() => {
+        elem.foo = 'baz';
+      });
+    });
   });
 
   describe('attachShadow', () => {


### PR DESCRIPTION
This fixes #1134.

When properties change, the renderer function is called. This is done by implementing propsChangedCallback within with-render.

Also fixes an issue where any renders after the first would not result in the shadowRoot being updated, because we weren't passing the preact component back into preact's `render` method.