### PR TITLE
Add version field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "skatejs",
+  "version": "5.0.0-alpha.0",
   "description": "Skate is a library built on top of the W3C web component specs that enables you to write functional and performant web components with a very small footprint.",
   "license": "MIT",
   "author": "Trey Shugart <treshugart@gmail.com> (http://treshugart.github.io)",


### PR DESCRIPTION
Yarn complains if a package doesn't have a version field, even when pulled from GitHub. This adds one.