### PR TITLE
Allow elements to create their own shadow

### DIFF
--- a/src/with-render.js
+++ b/src/with-render.js
@@ -9,9 +9,13 @@ function attachShadow (elem) {
 }
 
 export const withRender = (Base = HTMLElement) => class extends Base {
-  propsChangedCallback () {
+  get renderRoot () {
     this[_shadowRoot] = this[_shadowRoot] || (this[_shadowRoot] = (this.shadowRoot || attachShadow(this)));
-    this.rendererCallback(this[_shadowRoot], () => this.renderCallback(this));
+    return this[_shadowRoot];
+  }
+
+  propsChangedCallback () {
+    this.rendererCallback(this.renderRoot, () => this.renderCallback(this));
     this.renderedCallback();
   }
 

--- a/src/with-render.js
+++ b/src/with-render.js
@@ -10,7 +10,7 @@ function attachShadow (elem) {
 
 export const withRender = (Base = HTMLElement) => class extends Base {
   propsChangedCallback () {
-    this[_shadowRoot] = this[_shadowRoot] || (this[_shadowRoot] = attachShadow(this));
+    this[_shadowRoot] = this[_shadowRoot] || (this[_shadowRoot] = (this.shadowRoot || attachShadow(this)));
     this.rendererCallback(this[_shadowRoot], () => this.renderCallback(this));
     this.renderedCallback();
   }

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -152,6 +152,28 @@ describe('withRender', () => {
     });
   });
 
+  describe('renderRoot', () => {
+    it('allows rendering to somewhere else', (done) => {
+      const Elem = define(class extends Component {
+        get renderRoot () {
+          return this;
+        }
+
+        renderCallback () {
+          return vdom('div');
+        }
+
+        renderedCallback () {
+          expect(this.firstChild.localName).toBe('div');
+        }
+      });
+
+      const elem = new Elem();
+      fixture(elem);
+      afterMutations(done);
+    });
+  });
+
   describe('attachShadow', () => {
     it('should render to the host node if attachShadow is falsy', () => {
       const Elem = define(class extends Component {

--- a/test/unit/with-render.spec.js
+++ b/test/unit/with-render.spec.js
@@ -129,6 +129,27 @@ describe('withRender', () => {
         elem.foo = 'baz';
       });
     });
+
+    it('should be called if element creates its own shadowRoot', (done) => {
+      const Elem = define(class extends Component {
+        constructor () {
+          super();
+          this.attachShadow({ mode: 'open' });
+        }
+
+        renderCallback () {
+          return vdom('div');
+        }
+
+        renderedCallback () {
+          expect(this.shadowRoot.firstChild.localName).toBe('div');
+        }
+      });
+
+      const elem = new Elem();
+      fixture(elem);
+      afterMutations(done);
+    });
   });
 
   describe('attachShadow', () => {


### PR DESCRIPTION
This ensures that we do not throw on the first render if the element already has a shadow DOM (such as if the element creates its own shadow in the constructor).

Closes #1140