### PR TITLE
#1151 - fix Object errors

### DIFF
--- a/src/emit.js
+++ b/src/emit.js
@@ -1,3 +1,5 @@
+import { Object } from './util';
+
 const defs = {
   bubbles: true,
   cancelable: true,

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -13,7 +13,8 @@ const {
 
 export {
   customElements,
-  HTMLElement
+  HTMLElement,
+  Object
 };
 
 export function dashCase (str) {

--- a/src/util/with-props.js
+++ b/src/util/with-props.js
@@ -1,4 +1,4 @@
-import { dashCase, keys, sym } from '.';
+import { dashCase, keys, Object, sym } from '.';
 
 const _definedProps = sym('_definedProps');
 const _normPropDef = sym('_normPropDef');


### PR DESCRIPTION
We either have to use `Object` from the global, or explicitly export it as a util and import it from that. The latter is probably better just in case it's overridden in a containing scope.