### PR TITLE
Use CustomEvent when available

### DIFF
--- a/src/emit.js
+++ b/src/emit.js
@@ -8,15 +8,6 @@ const defs: EventOptions = {
   composed: false
 };
 
-declare global{
-    interface CustomEventInit {
-        composed: boolean;
-    }
-    interface CustomEvent {
-        composed: boolean;
-    }
-}
-
 const hasNativeSupport = verifyNativeEventSupport();
 
 function verifyNativeEventSupport() {

--- a/src/emit.js
+++ b/src/emit.js
@@ -8,10 +8,36 @@ const defs: EventOptions = {
   composed: false
 };
 
+declare global{
+    interface CustomEventInit {
+        composed: boolean;
+    }
+    interface CustomEvent {
+        composed: boolean;
+    }
+}
+
+const hasNativeSupport = verifyNativeEventSupport();
+
+function verifyNativeEventSupport() {
+    try {
+        const detail = {};
+        const test = new CustomEvent('testEvent', { composed: true, detail });
+        return test.composed === true && test.detail === detail;
+    } catch (error) {
+        return false;
+    }
+}
+
 export function emit (elem: HTMLElement, name: string, opts: EventOptions): boolean {
   opts = { ...defs, ...opts };
-  const e: ComposedCustomEvent = document.createEvent('CustomEvent');
-  e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
-  Object.defineProperty(e, 'composed', { value: opts.composed });
+  let e: ComposedCustomEvent;
+  if(hasNativeSupport){
+    e = new CustomEvent(name, opts);
+  } else {
+    e: ComposedCustomEvent = document.createEvent('CustomEvent');
+    e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
+    Object.defineProperty(e, 'composed', { value: opts.composed }); 
+  }
   return elem.dispatchEvent(e);
 }

--- a/src/emit.js
+++ b/src/emit.js
@@ -8,22 +8,10 @@ const defs: EventOptions = {
   composed: false
 };
 
-const hasNativeSupport = verifyNativeEventSupport();
-
-function verifyNativeEventSupport () {
-  try {
-    const detail = {};
-    const test = new CustomEvent('testEvent', { composed: true, detail });
-    return test.composed === true && test.detail === detail;
-  } catch (error) {
-    return false;
-  }
-}
-
 export function emit (elem: HTMLElement, name: string, opts: EventOptions): boolean {
   opts = { ...defs, ...opts };
   let e: ComposedCustomEvent;
-  if (hasNativeSupport) {
+  if ('composed' in CustomEvent.prototype) {
     e = new CustomEvent(name, opts);
   } else {
     e = document.createEvent('CustomEvent');

--- a/src/emit.js
+++ b/src/emit.js
@@ -26,7 +26,7 @@ export function emit (elem: HTMLElement, name: string, opts: EventOptions): bool
   if(hasNativeSupport){
     e = new CustomEvent(name, opts);
   } else {
-    e: ComposedCustomEvent = document.createEvent('CustomEvent');
+    e = document.createEvent('CustomEvent');
     e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
     Object.defineProperty(e, 'composed', { value: opts.composed }); 
   }

--- a/src/emit.js
+++ b/src/emit.js
@@ -10,7 +10,7 @@ const defs: EventOptions = {
 
 const hasNativeSupport = verifyNativeEventSupport();
 
-function verifyNativeEventSupport() {
+function verifyNativeEventSupport () {
   try {
     const detail = {};
     const test = new CustomEvent('testEvent', { composed: true, detail });
@@ -28,7 +28,7 @@ export function emit (elem: HTMLElement, name: string, opts: EventOptions): bool
   } else {
     e = document.createEvent('CustomEvent');
     e.initCustomEvent(name, opts.bubbles, opts.cancelable, opts.detail);
-    Object.defineProperty(e, 'composed', { value: opts.composed }); 
+    Object.defineProperty(e, 'composed', { value: opts.composed });
   }
   return elem.dispatchEvent(e);
 }

--- a/src/emit.js
+++ b/src/emit.js
@@ -11,19 +11,19 @@ const defs: EventOptions = {
 const hasNativeSupport = verifyNativeEventSupport();
 
 function verifyNativeEventSupport() {
-    try {
-        const detail = {};
-        const test = new CustomEvent('testEvent', { composed: true, detail });
-        return test.composed === true && test.detail === detail;
-    } catch (error) {
-        return false;
-    }
+  try {
+    const detail = {};
+    const test = new CustomEvent('testEvent', { composed: true, detail });
+    return test.composed === true && test.detail === detail;
+  } catch (error) {
+    return false;
+  }
 }
 
 export function emit (elem: HTMLElement, name: string, opts: EventOptions): boolean {
   opts = { ...defs, ...opts };
   let e: ComposedCustomEvent;
-  if(hasNativeSupport){
+  if (hasNativeSupport) {
     e = new CustomEvent(name, opts);
   } else {
     e = document.createEvent('CustomEvent');


### PR DESCRIPTION
There seems to be a problem with skatejs.emit when an emitting component is part of the shadowDOM template of another component specifically in Chrome; The event never bubbles out of the shadowDOM even with the use of {composed: true}. 

Test Case (using TypeScript): 
```JS
import { Component, h, emit } from 'skatejs';

export class Wrapper extends Component<void> {
    static get is() { return 'el-wrapper'; }

    constructor() {
        super();
        // Never reached :(
        this.addEventListener('internal-event', (event) => console.log('Event received', event));
    }

    renderCallback(){
        return (
            <div><el-emitter></el-emitter></div>
        );
    }
}
customElements.define(Wrapper.is, Wrapper);

export class Emitter extends Component<void> {
    static get is() { return 'el-emitter'; }

    connectedCallback() {
        super.connectedCallback();
        console.log('Sending event');
        emit(this, 'internal-event', { composed: true });
    }

    renderCallback(){
        return (<div>Hello World!</div>);
    }
}

declare global {
    namespace JSX {
        interface IntrinsicElements {
            'el-emitter': Partial<HTMLElement>
        }
    }
}
customElements.define(Emitter.is, Emitter);
```