### PR TITLE
refactor(render): Simplify withRender.renderRoot getter implementation

### DIFF
--- a/src/with-renderer.js
+++ b/src/with-renderer.js
@@ -16,10 +16,7 @@ export const withRenderer = (
     rendererCallback: Function | void;
 
     get renderRoot() {
-      this._shadowRoot =
-        this._shadowRoot ||
-        (this._shadowRoot = this.shadowRoot || attachShadow(this));
-      return this._shadowRoot;
+      return this._shadowRoot || (this._shadowRoot = (this.shadowRoot || attachShadow(this)));
     }
 
     propsChangedCallback() {


### PR DESCRIPTION
Refactors `withRender.renderRoot` getter method to avoid reassigning `_shadowRoot` property each time is called and remove redundant line.