### PR TITLE
Fix shared props

### DIFF
--- a/test/unit/with-props.spec.js
+++ b/test/unit/with-props.spec.js
@@ -55,6 +55,7 @@ describe("withProps", () => {
         ...{ test3: {} }
       }
     }
+    class Test4 extends Test1 {}
 
     expect(typeof Test1.props.test1).toBe('object');
     expect(typeof Test1.props.test2).toBe('undefined');
@@ -65,6 +66,9 @@ describe("withProps", () => {
     expect(typeof Test3.props.test1).toBe('object');
     expect(typeof Test3.props.test2).toBe('undefined');
     expect(typeof Test3.props.test3).toBe('object');
+    expect(typeof Test4.props.test1).toBe('object');
+    expect(typeof Test4.props.test2).toBe('undefined');
+    expect(typeof Test4.props.test3).toBe('undefined');
   });
 
   describe("array", () => {

--- a/test/unit/with-props.spec.js
+++ b/test/unit/with-props.spec.js
@@ -38,6 +38,35 @@ function testTypeValues(type, values, done) {
 }
 
 describe("withProps", () => {
+  it('should not share _props instance', () => {
+    class Test1 extends withProps() {
+      static props = {
+        test1: {}
+      }
+    }
+    class Test2 extends Test1 {
+      static props = {
+        test2: {}
+      }
+    }
+    class Test3 extends Test1 {
+      static props = {
+        ...Test1.props,
+        ...{ test3: {} }
+      }
+    }
+
+    expect(typeof Test1.props.test1).toBe('object');
+    expect(typeof Test1.props.test2).toBe('undefined');
+    expect(typeof Test1.props.test3).toBe('undefined');
+    expect(typeof Test2.props.test1).toBe('undefined');
+    expect(typeof Test2.props.test2).toBe('object');
+    expect(typeof Test2.props.test3).toBe('undefined');
+    expect(typeof Test3.props.test1).toBe('object');
+    expect(typeof Test3.props.test2).toBe('undefined');
+    expect(typeof Test3.props.test3).toBe('object');
+  });
+
   describe("array", () => {
     let elem;
 


### PR DESCRIPTION
## Requirements

- [x] The commit message follows [our guidelines](https://github.com/skatej/skatej/blob/master/docs/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)

## Breaking changes

- [ ] Yes
- [x] No

## Description

If you created a base class and based several components off of it, it would contain *all* of the props for every component deriving from it. This doesn't normally happen because mixins create new classes, but it shows up if you reuse a base class.