### PR TITLE
Doc changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,30 @@
 # Contributing
 
+## Technical overview
+
+Skate's source is kept in `src/`. It is written using the latest ES2017 version, with Flow type definitions.
+
+When Skate is built, it is transpiled in to various distribution formats, ready for use
+in the browser, on a server, or in a webpack build.
+
+The documentation for Skate is kept in `site/`, and is written using Skate with server-side rendering.
+
+Unit tests exist both for the source and for the documentation examples.
+
+## Getting started
+
+Skate uses `npm` as its package manager. Ensure you're on `npm@5` at a minimum.
+
+Here are the main commands you'll need while developing:
+
 - Creating a bundle: `npm prepublish`
-- Working on docs: `npm run docs:watch` / `yarn docs:watch`
-- Developing with tests: `npm run test:watch` / `yarn test:watch`
-- Fixing js and ts code style: `npm run style:fix` / `yarn style:fix`
-- Commiting (with commitizen): `npm run commit` / `yarn commit`
+- Developing with tests: `npm run test:watch`
+- Fixing js and ts code style: `npm run style:fix`
+- Commiting (with commitizen): `npm run commit`
+
+## Making a change
+
+All changes to Skate should be include an accompanying test case to demonstrate the feature or bug being addressed.
 
 ## Committing
 
@@ -12,7 +32,7 @@ We are using semantic-release and conventional-changelog for releasing, so our c
 
 The commit message formatting can be added using a typical git workflow or through the use of a CLI wizard ([Commitizen](https://github.com/commitizen/cz-cli)).
 
-To use the wizard, run `npm run commit` or `yarn commit` in your terminal after staging your changes in git.
+To use the wizard, run `npm run commit` in your terminal after staging your changes in git.
 
 A detailed explanation can be found in this [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#).
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For example, to create a simple greeting component:
 We could define a Skate component that renders the contents of our Custom Element:
 
 ```js
-import { withComponent, withRenderer } from 'skatejs';
+import { withComponent } from 'skatejs';
 
-const Component = withComponent(withRenderer());
+const Component = withComponent();
 
 class GreetingComponent extends Component {
   rendererCallback (renderRoot, renderCallback) {
@@ -71,9 +71,9 @@ This is the utility that web components provide when using Custom Elements and t
 We can create a Skate component that watches for HTML attribute changes on itself:
 
 ```js
-import { props, withComponent, withRenderer, withProps } from 'skatejs';
+import { props, withComponent } from 'skatejs';
 
-const Component = withComponent(withProps(withRenderer()));
+const Component = withComponent();
 
 class GreetingComponent extends Component {
   static props = {
@@ -84,7 +84,9 @@ class GreetingComponent extends Component {
     renderRoot.appendChild(renderCallback());
   }
   renderCallback ({ name }) {
-    return <span>Hello, {name}!</span>;
+      let el = document.createElement('span');
+      el.innerHTML = `Hello, ${name}!`;
+      return el;
   }
 });
 
@@ -116,7 +118,7 @@ check the [Installing](#installing) section.
 #### Using Skate with Preact
 
 Instead of writing our own `rendererCallback`, we could use a library like
-[Preact]() to do the work for us. Skate provides a ready-made renderer for Preact;
+[Preact](https://preactjs.com/) to do the work for us. Skate provides a ready-made renderer for Preact;
 here's how we would update our previous greeting component to use it:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/skatejs.svg)](https://saucelabs.com/u/skatejs)
 
-Skate is high level, functional abstraction over the web component [specs](https://github.com/w3c/webcomponents) that:
+Skate is a functional abstraction over [the web component standards](https://github.com/w3c/webcomponents) that:
 
 - Produces cross-framework compatible components
 - Abstracts away common attribute / property semantics via `props`, such as attribute reflection and coercion
@@ -52,10 +52,10 @@ JavaScript (using the Preact renderer)
 /** @jsx h */
 
 import { props, withComponent } from 'skatejs';
-import withPreact from '@skatejs/renderer-preact';
+import withRenderer from '@skatejs/renderer-preact';
 import { h } from 'preact';
 
-const Component = withComponent(withPreact());
+const Component = withComponent(withRenderer());
 
 customElements.define('x-hello', class extends Component {
   static props = {
@@ -76,13 +76,20 @@ Result
 </x-hello>
 ```
 
-Whenever you change the `name` property - or attribute - the component will re-render, only changing the part of the DOM that requires updating.
+Whenever you change the `name` property or attribute, the component will re-render,
+only changing the part of the DOM that requires updating.
 
 ## Polyfills
 
-Skate uses both Custom Elements and Shadow DOM, but is capable of operating without Shadow DOM, you just don't get any encapsulation.
+At its core, Skate is about creating [Custom Elements](https://w3c.github.io/webcomponents/spec/custom/).
+Skate also works with [the Shadow DOM](https://w3c.github.io/webcomponents/spec/shadow/), but is
+capable of operating without it -- you just don't get any encapsulation of your component's HTML or styles.
 
-For more information on the polyfills, see [their docs](https://github.com/webcomponents/webcomponentsjs).
+Though most modern browsers support these standards, some still need polyfills to implement missing or inconsistent
+behaviours for them.
+
+For more information on the polyfills, see
+[the web components polyfill documentation](https://github.com/webcomponents/webcomponentsjs).
 
 ## Browser Support
 

--- a/site/components/_.js
+++ b/site/components/_.js
@@ -5,7 +5,7 @@ import val from '@skatejs/val';
 import hljs from 'highlight.js';
 import { h as preactH } from 'preact';
 
-import { define, props, withComponent } from '../..';
+import { define, props, withComponent } from '../../src';
 
 const fs = require('fs');
 

--- a/site/index.js
+++ b/site/index.js
@@ -2,6 +2,9 @@
 
 import { define } from "../src";
 import { Code, Component, Heading, Hero, Layout, h } from "./components/_";
+import loadSample from "./utils/load-sample";
+
+const simple = loadSample('simple');
 
 export default define(
   class Index extends Component {
@@ -13,34 +16,14 @@ export default define(
             <p>Basic usage:</p>
             <Code
               lang="js"
-              src={`
-              import { withComponent } from 'skatejs';
-
-              let Component = withComponent();
-
-              class MyComponent extends Component {
-                  rendererCallback (renderRoot, renderCallback) {
-                    renderRoot.innerHtml = '';
-                    renderRoot.appendChild(renderCallback());
-                  }
-                  renderCallback () {
-                      let el = document.createElement('div');
-                      el.innerHTML = 'Hello, <slot></slot>!';
-                      return el;
-                  }
-              }
-
-              customElements.define('my-component', MyComponent);
-              `}
+              src={simple.source}
             />
             <Code
               lang="html"
-              src={`
-                <my-component>World</my-component>
-              `}
+              src={simple.html}
             />
             <p>Would render:</p>
-            <Code lang="html" src={`Hello, World!`} />
+            <Code lang="html" src={simple.result} />
           </Hero>
           <p>To install Skate, all you have to do is run:</p>
           <Code lang="sh" src={`npm install skatejs`} />

--- a/site/index.js
+++ b/site/index.js
@@ -12,27 +12,50 @@ export default define(
             <Heading>SkateJS</Heading>
             <p>Basic usage:</p>
             <Code
+              lang="js"
               src={`
-              /** @jsx h */
+              import { withComponent, withRenderer } from 'skatejs';
 
-              import { Component, h } from 'skatejs';
+              let Component = withComponent(withRenderer());
 
               class MyComponent extends Component {
-                renderCallback () {
-                  return <div>Hello, <slot />!</div>;
-                }
+                  rendererCallback (renderRoot, renderCallback) {
+                    renderRoot.innerHtml = '';
+                    renderRoot.appendChild(renderCallback());
+                  }
+                  renderCallback () {
+                      let el = document.createElement('div');
+                      el.innerHTML = 'Hello, <slot></slot>!';
+                      return el;
+                  }
               }
-            `}
+
+              customElements.define('my-component', MyComponent);
+              `}
+            />
+            <Code
+              lang="html"
+              src={`
+                <my-component>World</my-component>
+              `}
             />
             <p>Would render:</p>
             <Code lang="html" src={`Hello, World!`} />
           </Hero>
           <p>To install Skate, all you have to do is run:</p>
-          <Code lang="sh" src={`npm install skatejs preact`} />
+          <Code lang="sh" src={`npm install skatejs`} />
           <p>
-            Skate uses Preact as its default renderer when you extend{" "}
-            <code>Component</code>. You don't have to do this if you're using a
-            custom renderer.
+            Because Skate provides a hook for the renderer, it can support just about
+            every modern component-based front-end library &mdash; React, Preact, Vue...
+            just provide the <code>rendererCallback</code> and it's all the same to Skate!
+          </p>
+          <p>
+            The Skate team have provided a few renderers for popular front-end libraries:
+            <ul>
+              <li><a href="https://github.com/skatejs/renderer-react"><code>@skatejs/renderer-react</code></a></li>
+              <li><a href="https://github.com/skatejs/renderer-preact"><code>@skatejs/renderer-preact</code></a></li>
+              <li><a href="https://github.com/skatejs/renderer-lit-html"><code>@skatejs/renderer-lit-html</code></a></li>
+            </ul>
           </p>
         </Layout>
       );

--- a/site/index.js
+++ b/site/index.js
@@ -14,9 +14,9 @@ export default define(
             <Code
               lang="js"
               src={`
-              import { withComponent, withRenderer } from 'skatejs';
+              import { withComponent } from 'skatejs';
 
-              let Component = withComponent(withRenderer());
+              let Component = withComponent();
 
               class MyComponent extends Component {
                   rendererCallback (renderRoot, renderCallback) {

--- a/site/utils/load-sample.js
+++ b/site/utils/load-sample.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const sampleRoot = path.resolve(__dirname, '..', '..', 'test', 'samples');
+
+function filterSource(src) {
+    return String(src).replace('../../../src', 'skatejs');
+}
+
+export default function loadSample(sampleName) {
+    let filePath = path.join(sampleRoot, sampleName);
+    let sourceFile = path.join(filePath, 'index.js');
+    if (fs.existsSync(sourceFile)) {
+        let source = fs.readFileSync(sourceFile, 'utf8');
+        let html = fs.readFileSync(path.join(filePath, 'index.html.js'), 'utf8');
+        let result = fs.readFileSync(path.join(filePath, 'index.result.js'), 'utf8');
+        return {
+            source: filterSource(source),
+            html,
+            result
+        };
+    }
+    throw new Error(`could not find sample ${sampleName} in ${sampleRoot}`);
+}

--- a/test/samples/simple/index.html.js
+++ b/test/samples/simple/index.html.js
@@ -1,0 +1,1 @@
+<hello-simple>World</hello-simple>

--- a/test/samples/simple/index.js
+++ b/test/samples/simple/index.js
@@ -1,6 +1,6 @@
-import { withComponent, withRenderer } from '../../../src';
+import { withComponent } from '../../../src';
 
-let Component = withComponent(withRenderer());
+let Component = withComponent();
 
 class MyComponent extends Component {
     rendererCallback (renderRoot, renderCallback) {

--- a/test/samples/simple/index.js
+++ b/test/samples/simple/index.js
@@ -1,0 +1,17 @@
+import { withComponent, withRenderer } from '../../../src';
+
+let Component = withComponent(withRenderer());
+
+class MyComponent extends Component {
+    rendererCallback (renderRoot, renderCallback) {
+      renderRoot.innerHtml = '';
+      renderRoot.appendChild(renderCallback());
+    }
+    renderCallback () {
+        let el = document.createElement('div');
+        el.innerHTML = 'Hello, <slot></slot>!';
+        return el;
+    }
+}
+
+customElements.define('hello-simple', MyComponent);

--- a/test/samples/simple/index.result.js
+++ b/test/samples/simple/index.result.js
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/samples/simple/index.spec.js
+++ b/test/samples/simple/index.spec.js
@@ -8,16 +8,17 @@ describe('samples/simple', () => {
         let el = document.createElement('hello-simple');
         mount( el ).wait(e => {
             expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
+            expect(e.node.textContent).toBe('');
             done();
         });
     });
 
-    xit('renders slot contents', (done) => {
+    it('renders slot contents', (done) => {
         let el = document.createElement('hello-simple');
         el.textContent = 'World';
         mount( el ).wait(e => {
             expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
-            expect(e.textContent).toBe('World');
+            expect(e.node.textContent).toBe('World');
             done();
         });
     });

--- a/test/samples/simple/index.spec.js
+++ b/test/samples/simple/index.spec.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import { mount } from '@skatejs/bore';
+import './';
+
+describe('samples/simple', () => {
+    it('renders what we expect', (done) => {
+        let el = document.createElement('hello-simple');
+        mount( el ).wait(e => {
+            expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
+            done();
+        });
+    });
+
+    xit('renders slot contents', (done) => {
+        let el = document.createElement('hello-simple');
+        el.textContent = 'World';
+        mount( el ).wait(e => {
+            expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
+            expect(e.textContent).toBe('World');
+            done();
+        });
+    });
+});

--- a/test/samples/with-preact/index.js
+++ b/test/samples/with-preact/index.js
@@ -1,10 +1,10 @@
 /** @jsx h */
 
-import { props, withProps, withComponent } from '../../../src';
+import { props, withComponent } from '../../../src';
 import withRenderer from '@skatejs/renderer-preact';
 import { h } from 'preact';
 
-const Component = withComponent(withProps(withRenderer()));
+const Component = withComponent(withRenderer());
 
 customElements.define('hello-withpreact', class MyPreactHello extends Component {
   static props = {

--- a/test/samples/with-preact/index.js
+++ b/test/samples/with-preact/index.js
@@ -1,7 +1,7 @@
 /** @jsx h */
 
 import { props, withComponent } from '../../../src';
-import withRenderer from '@skatejs/renderer-preact';
+import withRenderer from '@skatejs/renderer-preact/umd';
 import { h } from 'preact';
 
 const Component = withComponent(withRenderer());

--- a/test/samples/with-preact/index.js
+++ b/test/samples/with-preact/index.js
@@ -1,0 +1,16 @@
+/** @jsx h */
+
+import { props, withProps, withComponent } from '../../../src';
+import withRenderer from '@skatejs/renderer-preact';
+import { h } from 'preact';
+
+const Component = withComponent(withProps(withRenderer()));
+
+customElements.define('hello-withpreact', class MyPreactHello extends Component {
+  static props = {
+    name: props.string
+  }
+  renderCallback ({ name }) {
+    return <span>Hello, {name}!</span>;
+  }
+});

--- a/test/samples/with-preact/index.spec.js
+++ b/test/samples/with-preact/index.spec.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+
+import { mount } from '@skatejs/bore';
+import './';
+
+describe('samples/with-preact', () => {
+    xit('renders what we expect', (done) => {
+        let el = document.createElement('hello-withpreact');
+        mount( el ).wait(e => {
+            expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
+            done();
+        });
+    });
+});

--- a/test/samples/with-preact/index.spec.js
+++ b/test/samples/with-preact/index.spec.js
@@ -4,10 +4,21 @@ import { mount } from '@skatejs/bore';
 import './';
 
 describe('samples/with-preact', () => {
-    xit('renders what we expect', (done) => {
+    it('renders what we expect', (done) => {
         let el = document.createElement('hello-withpreact');
         mount( el ).wait(e => {
             expect(e.shadowRoot.firstChild.textContent).toBe('Hello, !');
+            expect(e.node.textContent).toBe('');
+            done();
+        });
+    });
+
+    it('renders props contents', (done) => {
+        let el = document.createElement('hello-withpreact');
+        el.name = 'World';
+        mount( el ).wait(e => {
+            expect(e.shadowRoot.firstChild.textContent).toBe('Hello, World!');
+            expect(e.node.textContent).toBe('');
             done();
         });
     });


### PR DESCRIPTION
## Requirements

- [x] The commit message follows [our guidelines](https://github.com/skatej/skatej/blob/master/docs/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Updated TypeScript definitions, if applicable
- [x] Update docs/migrating.md for breaking changes

## Related issues

#860, #903 

## Details

This is an attempt at demonstrating a few ways in which Skate can be utilised in the README, going from "simple" through to "complex", and making the "site" code orthogonal to it at the same time.

The two primary challenges with the docs are (1) the flow, and (2) their simplicity.

1. It's challenging to construct a linear flow through what Skate "is" and incremental examples of web components authored via Skate. The difficulty lies in requisite knowledge (i.e., what can we expect people to know prior to looking at Skate) and relevance (i.e., when people want to author web components, what will pique their interest the most?). This leads in to the second problem...
2. Simple examples of using Skate aren't that "simple" -- by that, I mean they end up looking less terse than I'd hoped.
    * If you compare a base Skate component to a base React/Preact one, the comparison is unfavourable, since there's more boilerplate for the base usage.
    * If you compare to a basic no-library web component, Skate is favourable, but only if you get in to the nitty-gritty of Skate's helper functions.

I'm not sure I've struck the right balance between a linear flow, terseness, and relevance yet. Comments and discussion are more than welcome.