### PR TITLE
fix: Symbol named props

### DIFF
--- a/src/util/with-props.js
+++ b/src/util/with-props.js
@@ -13,7 +13,7 @@ interface CanDefineProps extends HTMLElement {
 }
 
 export function normaliseAttributeDefinition(
-  name: string,
+  name: string | Symbol,
   prop: PropOptions
 ): Object {
   const { attribute } = prop;
@@ -25,10 +25,10 @@ export function normaliseAttributeDefinition(
           target: attribute
         };
   if (obj.source === true) {
-    obj.source = dashCase(name);
+    obj.source = typeof name === 'symbol' ? name : dashCase(name);
   }
   if (obj.target === true) {
-    obj.target = dashCase(name);
+    obj.target = typeof name === 'symbol' ? name : dashCase(name);
   }
   return obj;
 }

--- a/test/unit/with-props.spec.js
+++ b/test/unit/with-props.spec.js
@@ -302,7 +302,7 @@ describe("withProps", () => {
         class extends withUnique(withProps()) {
           static props = {
             [secret1]: null,
-            [secret2]: null,
+            [secret2]: props.any,
             public1: null,
             public2: null
           };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows [our guidelines](https://github.com/skatej/skatej/blob/master/docs/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
## Details
Fixes a bug where you can't use symbols as name of props if using the props helpers.

I'm not sure if this is the right approach, since I'm not entirely sure of the side effects of not having a dashCased string name.


