### PR TITLE
docs: Update commit message url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 **Please check if the PR fulfills these requirements**
-- [ ] The commit message follows [our guidelines](https://github.com/skatej/skatej/blob/master/docs/CONTRIBUTING.md#commit)
+- [ ] The commit message follows [our guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md#committing)
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] Updated TypeScript definitions, if applicable


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows [our guidelines](https://github.com/skatej/skatej/blob/master/docs/CONTRIBUTING.md#commit)
- [x] Docs have been added / updated (for bug fixes / features)

Just noticed the pull request template has a dead url, not sure if should be pointing to 5.x or master, but its currently broken