### PR TITLE
#1237 - Implement state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,4 +7,5 @@ export * from './with-children';
 export * from './with-component';
 export * from './with-props';
 export * from './with-renderer';
+export * from './with-state';
 export * from './with-unique';

--- a/src/with-component.js
+++ b/src/with-component.js
@@ -3,7 +3,10 @@
 import { withChildren } from './with-children';
 import { withProps } from './with-props';
 import { withRenderer } from './with-renderer';
+import { withState } from './with-state';
 import { withUnique } from './with-unique';
 
-export const withComponent = (Base?: Class<any>) =>
-  withChildren(withProps(withRenderer(withUnique(Base || HTMLElement))));
+export const withComponent = (Base?: Class<HTMLElement>) =>
+  withChildren(
+    withProps(withRenderer(withState(withUnique(Base || HTMLElement))))
+  );

--- a/src/with-props.js
+++ b/src/with-props.js
@@ -69,8 +69,6 @@ export const withProps = (
     static _observedAttributes: Array<string>;
     static _props: Object;
 
-    _connected: boolean;
-    _constructed: boolean;
     _prevProps: Object;
     _syncingAttributeToProperty: null | string;
     _syncingPropertyToAttribute: boolean;
@@ -120,24 +118,15 @@ export const withProps = (
 
     constructor() {
       super();
-      if (this._constructed) return;
-      this._constructed = true;
       this.triggerUpdateBatched = debounce(this.triggerUpdate.bind(this));
     }
 
     connectedCallback() {
-      if (this._connected) return;
-      this._connected = true;
-      // $FlowFixMe - HTMLElement doesn't implement connectedCallback.
-      if (super.connectedCallback) super.connectedCallback();
+      if (super.connectedCallback) {
+        // $FlowFixMe - not in HTMLElement.
+        super.connectedCallback();
+      }
       this.triggerUpdateBatched();
-    }
-
-    disconnectedCallback() {
-      if (!this._connected) return;
-      this._connected = false;
-      // $FlowFixMe - HTMLElement doesn't implement disconnectedCallback.
-      if (super.disconnectedCallback) super.disconnectedCallback();
     }
 
     // Called to see if the props changed.
@@ -158,7 +147,7 @@ export const withProps = (
 
     // Invokes the complete render lifecycle.
     triggerUpdate() {
-      if (this._updating || !this._connected) {
+      if (this._updating) {
         return;
       }
 

--- a/src/with-renderer.js
+++ b/src/with-renderer.js
@@ -10,7 +10,9 @@ export const withRenderer = (
   Base: Class<HTMLElement> = HTMLElement
 ): Class<HTMLElement> =>
   class extends Base {
+    _connected: boolean;
     _shadowRoot: Node;
+
     renderCallback: Function | void;
     renderedCallback: Function | void;
     rendererCallback: Function | void;
@@ -22,14 +24,28 @@ export const withRenderer = (
       );
     }
 
+    connectedCallback() {
+      if (super.connectedCallback) {
+        // $FlowFixMe - not in HTMLElement.
+        super.connectedCallback();
+      }
+      this._connected = true;
+    }
+
     propsChangedCallback() {
+      if (super.propsChangedCallback) {
+        // $FlowFixMe - not in HTMLElement.
+        super.propsChangedCallback();
+      }
+      if (!this._connected) {
+        return;
+      }
       if (this.rendererCallback) {
         this.rendererCallback(
           this.renderRoot,
           () => this.renderCallback && this.renderCallback(this)
         );
       }
-
       if (this.renderedCallback) {
         this.renderedCallback();
       }

--- a/src/with-state.js
+++ b/src/with-state.js
@@ -1,0 +1,15 @@
+export const withState = (
+  Base?: Class<HTMLElement> = HTMLElement
+): Class<HTMLElement> =>
+  class extends Base {
+    triggerUpdate: Function | void;
+    get state() {
+      return this._state || {};
+    }
+    set state(state: Object) {
+      this._state = state;
+      if (this.triggerUpdate) {
+        this.triggerUpdate();
+      }
+    }
+  };

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -24,6 +24,7 @@ describe('exports', () => {
     expect(typeof api.withComponent).toBe('function', 'withComponent');
     expect(typeof api.withProps).toBe('function', 'withProps');
     expect(typeof api.withRenderer).toBe('function', 'withRenderer');
+    expect(typeof api.withState).toBe('function', 'withState');
     expect(typeof api.withUnique).toBe('function', 'withUnique');
   });
 

--- a/test/unit/with-props.spec.js
+++ b/test/unit/with-props.spec.js
@@ -406,4 +406,13 @@ describe('withProps', () => {
     elem.triggerUpdate();
     expect(updated).toBe(true);
   });
+
+  it('triggerUpdateBatched', done => {
+    const elem = new class extends withProps() {
+      propsSetCallback() {
+        done();
+      }
+    }();
+    elem.triggerUpdateBatched();
+  });
 });

--- a/test/unit/with-props.spec.js
+++ b/test/unit/with-props.spec.js
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 
-import { h as preactH } from "preact";
-import { define, prop, props, withProps, withUnique } from "../../src";
-import { sym } from "../../src/util";
+import { h as preactH } from 'preact';
+import { define, prop, props, withProps, withUnique } from '../../src';
+import { sym } from '../../src/util';
 
-import afterMutations from "../lib/after-mutations";
-import fixture from "../lib/fixture";
+import afterMutations from '../lib/after-mutations';
+import fixture from '../lib/fixture';
 
 function create(propLocal) {
   const el = new (define(
@@ -28,32 +28,32 @@ function testTypeValues(type, values, done) {
         value[1],
         `prop ${value[0]}: ${elem.test} != ${value[1]}`
       );
-      expect(elem.getAttribute("test")).toEqual(
+      expect(elem.getAttribute('test')).toEqual(
         value[2],
-        `attr ${value[0]}: ${elem.getAttribute("test")} != ${value[2]}`
+        `attr ${value[0]}: ${elem.getAttribute('test')} != ${value[2]}`
       );
     });
     done();
   }, 1);
 }
 
-describe("withProps", () => {
+describe('withProps', () => {
   it('should not share _props instance', () => {
     class Test1 extends withProps() {
       static props = {
         test1: {}
-      }
+      };
     }
     class Test2 extends Test1 {
       static props = {
         test2: {}
-      }
+      };
     }
     class Test3 extends Test1 {
       static props = {
         ...Test1.props,
         ...{ test3: {} }
-      }
+      };
     }
     class Test4 extends Test1 {}
 
@@ -71,7 +71,7 @@ describe("withProps", () => {
     expect(typeof Test4.props.test3).toBe('undefined');
   });
 
-  describe("array", () => {
+  describe('array', () => {
     let elem;
 
     beforeEach(done => {
@@ -81,67 +81,67 @@ describe("withProps", () => {
 
     afterEach(() => document.body.removeChild(elem));
 
-    it("default", () => {
+    it('default', () => {
       const elem2 = create(props.array);
 
-      expect(typeof elem.test).toBe("object");
-      expect(elem.test).toEqual(elem2.test, "should be shared");
-      expect(Object.isFrozen(elem.test)).toEqual(true, "should be frozen");
-      expect(elem.test.length).toEqual(0, "should not contain any items");
-      expect(elem.getAttribute("test")).toEqual(
+      expect(typeof elem.test).toBe('object');
+      expect(elem.test).toEqual(elem2.test, 'should be shared');
+      expect(Object.isFrozen(elem.test)).toEqual(true, 'should be frozen');
+      expect(elem.test.length).toEqual(0, 'should not contain any items');
+      expect(elem.getAttribute('test')).toEqual(
         null,
-        "should not set the attribute"
+        'should not set the attribute'
       );
     });
 
-    describe("coerce", () => {
-      it("set array", () => {
-        const arr = ["something"];
+    describe('coerce', () => {
+      it('set array', () => {
+        const arr = ['something'];
         elem.test = arr;
         expect(elem.test).toEqual(arr);
       });
 
-      it("set non-array", () => {
-        elem.test = "something";
-        expect(typeof elem.test).toBe("object");
+      it('set non-array', () => {
+        elem.test = 'something';
+        expect(typeof elem.test).toBe('object');
         expect(elem.test.length).toEqual(1);
-        expect(elem.test[0]).toEqual("something");
+        expect(elem.test[0]).toEqual('something');
       });
     });
 
-    it("deserialize", done => {
-      elem.setAttribute("test", '["val1","val2"]');
+    it('deserialize', done => {
+      elem.setAttribute('test', '["val1","val2"]');
       afterMutations(
-        () => expect(typeof elem.test).toBe("object"),
+        () => expect(typeof elem.test).toBe('object'),
         () => expect(elem.test.length).toBe(2),
-        () => expect(elem.test[0]).toEqual("val1"),
-        () => expect(elem.test[1]).toEqual("val2"),
+        () => expect(elem.test[0]).toEqual('val1'),
+        () => expect(elem.test[1]).toEqual('val2'),
         done
       );
     });
 
-    it("serialize", () => {
-      elem.test = ["val1", "val2"];
-      expect(elem.getAttribute("test")).toEqual('["val1","val2"]');
+    it('serialize', () => {
+      elem.test = ['val1', 'val2'];
+      expect(elem.getAttribute('test')).toEqual('["val1","val2"]');
     });
   });
 
-  describe("boolean", () => {
-    it("default", () => {
+  describe('boolean', () => {
+    it('default', () => {
       const elem = create(props.boolean);
       expect(elem.test).toEqual(false);
-      expect(elem.getAttribute("test")).toEqual(null);
+      expect(elem.getAttribute('test')).toEqual(null);
     });
 
-    [undefined, null, false, 0, "", "something"].forEach(value => {
+    [undefined, null, false, 0, '', 'something'].forEach(value => {
       value = String(value);
       it(`setting attribute to ${JSON.stringify(value)}`, done => {
         const elem = create(props.boolean);
         afterMutations(() => {
-          elem.setAttribute("test", value);
+          elem.setAttribute('test', value);
           afterMutations(() => {
-            expect(elem.test).toEqual(true, "property");
-            expect(elem.getAttribute("test")).toEqual(value, "attribute");
+            expect(elem.test).toEqual(true, 'property');
+            expect(elem.getAttribute('test')).toEqual(value, 'attribute');
             done();
           }, 1);
         });
@@ -150,31 +150,31 @@ describe("withProps", () => {
         const elem = create(props.boolean);
         afterMutations(() => {
           elem.test = value;
-          expect(elem.test).toEqual(Boolean(value), "property");
-          expect(elem.getAttribute("test")).toEqual(
-            elem.test ? "" : null,
-            "attribute"
+          expect(elem.test).toEqual(Boolean(value), 'property');
+          expect(elem.getAttribute('test')).toEqual(
+            elem.test ? '' : null,
+            'attribute'
           );
           done();
         });
       });
     });
 
-    it("removing attribute", done => {
+    it('removing attribute', done => {
       const elem = create(props.boolean);
       afterMutations(
-        () => elem.setAttribute("test", ""),
+        () => elem.setAttribute('test', ''),
         () => expect(elem.test).toEqual(true),
-        () => expect(elem.getAttribute("test")).toEqual(""),
-        () => elem.removeAttribute("test"),
+        () => expect(elem.getAttribute('test')).toEqual(''),
+        () => elem.removeAttribute('test'),
         () => expect(elem.test).toEqual(false),
-        () => expect(elem.getAttribute("test")).toEqual(null),
+        () => expect(elem.getAttribute('test')).toEqual(null),
         done
       );
     });
   });
 
-  describe("number", () => {
+  describe('number', () => {
     let elem;
 
     beforeEach(done => {
@@ -182,42 +182,42 @@ describe("withProps", () => {
       afterMutations(done);
     });
 
-    it("default", () => {
-      expect(typeof elem.test).toBe("number");
+    it('default', () => {
+      expect(typeof elem.test).toBe('number');
       expect(elem.test).toEqual(0);
-      expect(elem.getAttribute("test")).toEqual(null);
+      expect(elem.getAttribute('test')).toEqual(null);
     });
 
-    it("values", done => {
+    it('values', done => {
       testTypeValues(
-        "number",
+        'number',
         [
-          [false, 0, "0"],
-          [true, 1, "1"],
+          [false, 0, '0'],
+          [true, 1, '1'],
           [null, 0, null],
           [undefined, 0, null],
-          [0.1, 0.1, "0.1"],
-          ["test", NaN, "NaN"],
-          ["", 0, "0"]
+          [0.1, 0.1, '0.1'],
+          ['test', NaN, 'NaN'],
+          ['', 0, '0']
         ],
         done
       );
     });
 
-    it("removing attribute", done => {
+    it('removing attribute', done => {
       afterMutations(
-        () => elem.setAttribute("test", ""),
+        () => elem.setAttribute('test', ''),
         () => expect(elem.test).toEqual(0),
-        () => expect(elem.getAttribute("test")).toEqual(""),
-        () => elem.removeAttribute("test"),
+        () => expect(elem.getAttribute('test')).toEqual(''),
+        () => elem.removeAttribute('test'),
         () => expect(elem.test).toEqual(0),
-        () => expect(elem.getAttribute("test")).toEqual(null),
+        () => expect(elem.getAttribute('test')).toEqual(null),
         done
       );
     });
   });
 
-  describe("object", () => {
+  describe('object', () => {
     let elem;
 
     beforeEach(done => {
@@ -225,49 +225,49 @@ describe("withProps", () => {
       afterMutations(done);
     });
 
-    it("default", () => {
+    it('default', () => {
       const elem2 = create(props.object);
 
-      expect(typeof elem.test).toBe("object");
-      expect(elem.test).toEqual(elem2.test, "should be shared");
-      expect(Object.isFrozen(elem.test)).toEqual(true, "should be frozen");
-      expect(elem.getAttribute("test")).toEqual(
+      expect(typeof elem.test).toBe('object');
+      expect(elem.test).toEqual(elem2.test, 'should be shared');
+      expect(Object.isFrozen(elem.test)).toEqual(true, 'should be frozen');
+      expect(elem.getAttribute('test')).toEqual(
         null,
-        "should not set the attribute"
+        'should not set the attribute'
       );
     });
 
-    it("deserialize", done => {
-      elem.setAttribute("test", '{"one": 1, "two": 2}');
+    it('deserialize', done => {
+      elem.setAttribute('test', '{"one": 1, "two": 2}');
       afterMutations(
-        () => expect(typeof elem.test).toBe("object"),
+        () => expect(typeof elem.test).toBe('object'),
         () => expect(elem.test.one).toEqual(1),
         () => expect(elem.test.two).toEqual(2),
         done
       );
     });
 
-    it("serialize", () => {
+    it('serialize', () => {
       elem.test = { one: 1, two: 2 };
-      expect(typeof elem.getAttribute("test")).toBe("string");
-      expect(elem.getAttribute("test")).toEqual('{"one":1,"two":2}');
+      expect(typeof elem.getAttribute('test')).toBe('string');
+      expect(elem.getAttribute('test')).toEqual('{"one":1,"two":2}');
     });
   });
 
-  describe("string", () => {
-    it("values", done => {
+  describe('string', () => {
+    it('values', done => {
       const elem = create(props.string);
       afterMutations(() => {
-        expect(elem.test).toEqual("");
-        expect(elem.getAttribute("test")).toEqual(null);
+        expect(elem.test).toEqual('');
+        expect(elem.getAttribute('test')).toEqual(null);
         testTypeValues(
-          "string",
+          'string',
           [
-            [false, "false", "false"],
-            [null, "null", null],
-            [undefined, "undefined", null],
-            [0, "0", "0"],
-            ["", "", ""]
+            [false, 'false', 'false'],
+            [null, 'null', null],
+            [undefined, 'undefined', null],
+            [0, '0', '0'],
+            ['', '', '']
           ],
           done
         );
@@ -275,10 +275,10 @@ describe("withProps", () => {
     });
   });
 
-  describe("sanity", () => {
-    const types = ["array", "boolean", "number", "object", "string"];
+  describe('sanity', () => {
+    const types = ['array', 'boolean', 'number', 'object', 'string'];
 
-    describe("default one-way attribute -> prop reflection", () => {
+    describe('default one-way attribute -> prop reflection', () => {
       const attribute = { source: true };
       types.forEach(type => {
         it(type, () => {
@@ -288,14 +288,14 @@ describe("withProps", () => {
     });
   });
 
-  describe("*Props()", () => {
+  describe('*Props()', () => {
     if (typeof Symbol === 'undefined') {
       return;
     }
 
     let elem;
-    const secret1 = sym("secret1");
-    const secret2 = sym("secret2");
+    const secret1 = sym('secret1');
+    const secret2 = sym('secret2');
 
     beforeEach(done => {
       elem = new (define(
@@ -309,11 +309,11 @@ describe("withProps", () => {
           constructor() {
             super();
             this._rendered = 0;
-            this[secret1] = "secretKey1";
-            this[secret2] = "secretKey2";
-            this.public1 = "publicKey1";
-            this.public2 = "publicKey2";
-            this.undeclaredProp = "undeclaredKey1";
+            this[secret1] = 'secretKey1';
+            this[secret2] = 'secretKey2';
+            this.public1 = 'publicKey1';
+            this.public2 = 'publicKey2';
+            this.undeclaredProp = 'undeclaredKey1';
           }
           propsSetCallback() {
             this._rendered++;
@@ -324,8 +324,8 @@ describe("withProps", () => {
       afterMutations(done);
     });
 
-    describe("static props", () => {
-      it("should not merge super props", () => {
+    describe('static props', () => {
+      it('should not merge super props', () => {
         const one = {};
         const two = {};
         class One extends withProps() {
@@ -339,60 +339,71 @@ describe("withProps", () => {
       });
     });
 
-    describe("props", () => {
-      it("should return only properties defined as props", () => {
+    describe('props', () => {
+      it('should return only properties defined as props', () => {
         const curr = elem.props;
 
         expect(secret1 in curr).toEqual(true);
         expect(secret2 in curr).toEqual(true);
-        expect("public1" in curr).toEqual(true);
-        expect("public2" in curr).toEqual(true);
+        expect('public1' in curr).toEqual(true);
+        expect('public2' in curr).toEqual(true);
 
-        expect(curr[secret1]).toEqual("secretKey1");
-        expect(curr[secret2]).toEqual("secretKey2");
-        expect(curr.public1).toEqual("publicKey1");
-        expect(curr.public2).toEqual("publicKey2");
+        expect(curr[secret1]).toEqual('secretKey1');
+        expect(curr[secret2]).toEqual('secretKey2');
+        expect(curr.public1).toEqual('publicKey1');
+        expect(curr.public2).toEqual('publicKey2');
 
         expect(curr.undeclaredProp).toEqual(undefined);
       });
 
-      describe("setter", () => {
-        it("should set props", () => {
-          elem.props = { public1: "updated" };
-          expect(elem.public1).toBe("updated");
+      describe('setter', () => {
+        it('should set props', () => {
+          elem.props = { public1: 'updated' };
+          expect(elem.public1).toBe('updated');
         });
 
-        it("should set symbols", () => {
-          elem.props = { [secret1]: "updated" };
-          expect(elem[secret1]).toBe("updated");
+        it('should set symbols', () => {
+          elem.props = { [secret1]: 'updated' };
+          expect(elem[secret1]).toBe('updated');
         });
 
-        it("should not affect unpassed props", () => {
-          elem.props = { public1: "updated" };
-          expect(elem.public2).toBe("publicKey2");
+        it('should not affect unpassed props', () => {
+          elem.props = { public1: 'updated' };
+          expect(elem.public2).toBe('publicKey2');
         });
 
-        it("should not affect undeclared props", () => {
-          elem.props = { undeclared: "yay" };
+        it('should not affect undeclared props', () => {
+          elem.props = { undeclared: 'yay' };
           expect(elem.undeclared).toBe(undefined);
         });
       });
     });
   });
 
-  describe("{ prop }", function() {
-    it("should define a property on an element", () => {
+  describe('{ prop }', function() {
+    it('should define a property on an element', () => {
       const elem = new class extends withProps() {}();
 
-      prop({ ...props.string, ...{ attribute: true } })(elem, "test");
+      prop({ ...props.string, ...{ attribute: true } })(elem, 'test');
 
-      expect(elem.test).toBe("");
-      expect(elem.hasAttribute("test")).toEqual(false);
+      expect(elem.test).toBe('');
+      expect(elem.hasAttribute('test')).toEqual(false);
 
       elem.test = true;
 
-      expect(elem.test).toBe("true");
-      expect(elem.hasAttribute("test")).toEqual(true);
+      expect(elem.test).toBe('true');
+      expect(elem.hasAttribute('test')).toEqual(true);
     });
+  });
+
+  it('triggerUpdate', () => {
+    let updated;
+    const elem = new class extends withProps() {
+      propsSetCallback() {
+        updated = true;
+      }
+    }();
+    elem.triggerUpdate();
+    expect(updated).toBe(true);
   });
 });

--- a/test/unit/with-state.spec.js
+++ b/test/unit/with-state.spec.js
@@ -1,0 +1,28 @@
+import { define, withState, withUnique } from '../../src';
+
+const Base = withState(withUnique());
+
+describe('withState', () => {
+  it('should set state', () => {
+    const Test = define(class extends Base {});
+    const test = new Test();
+    const newState = { test1: true, test2: false };
+    expect(test.state).toMatchObject({});
+    test.state = newState;
+    expect(test.state).toMatchObject(newState);
+  });
+
+  it('should call triggerUpdate', () => {
+    let updated;
+    const Test = define(
+      class extends Base {
+        triggerUpdate() {
+          updated = true;
+        }
+      }
+    );
+    const test = new Test();
+    test.state = {};
+    expect(updated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Implementation

#1237

This implements state using a separate mixin. The mixin has a getter and setter that calls `triggerUpdate` if it's defined on the instance.

## Tests

The tests test both setting and that `triggerUpdate` is called. All other functionality is assumed ot be borrowed from something like `withProps` that implements a `triggerUpdate` method.

## Other

Theres some other stuff here:

- Moved the `_connected` check to `withRender`. No use in doing this in the props mixin unless we really want to block any props reactions when not connected. We should be doing this check in `withRender` anyways even if it's done in props.
- Added tests to `withProps` to ensure `triggerUpdate` and `triggerUpdateBatched` are called.

## Open questions

- Should we mix this in with `withProps`? I feel like too many mixins are going to get us into perf trouble.
- Do we want to continue checking `_connected` in `withProps` before calling `propsChangedCallback` or are we okay with calling that even when it's not connected? I feel this would break people's expectations, but not with rendering (or maybe at some point have an option for that for rendering).