### PR TITLE
Clarify lit html renderer

### DIFF
--- a/packages/renderer-lit-html/README.md
+++ b/packages/renderer-lit-html/README.md
@@ -2,6 +2,10 @@
 
 SkateJS renderer for [Lit HTML](https://github.com/PolymerLabs/lit-html).
 
+Please note `renderer-lit-html` uses Lit HTML's extended renderer by default. This provides slightly different
+than default, and enhanced, functionality as described
+[here](https://github.com/PolymerLabs/lit-html/blob/master/src/lib/lit-extended.ts#L25).
+
 ## Install
 
 ```sh

--- a/site/pages/renderers/with-lit-html.js
+++ b/site/pages/renderers/with-lit-html.js
@@ -27,6 +27,14 @@ export default class extends Component {
           allows you to render using
           <a href="https://github.com/PolymerLabs/lit-html">LitHTML</a>.
         </p>
+
+        <p>
+          Please note this renderer uses Lit HTML's extended renderer by default. This provides slightly different
+          than default, and enhanced, functionality as described
+          <a href="https://github.com/PolymerLabs/lit-html/blob/master/src/lib/lit-extended.ts#L25">
+            here
+          </a>.
+        </p>
         <x-runnable
           code="${codeWithLitHtml}"
           html="${codeWithLitHtmlHtml}"></x-runnable>


### PR DESCRIPTION
* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [x] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

I ran into the problem of attributes no longer rendering when migrating from direct usage of `lit-html`'s `render` in `connectedCallback` to `withLitHtml`. This lead me to realizing that the `withLitHtml` uses the extended render from `lit-html`. I was surprised since the extended renderer's exist isn't really loudly documented by `lit-html`'s readme. This change points to the extended renderer's docs and hopefully prevents others from going on the debugging journey I went on.

I wasn't sure if it made sense to update both the readme and the site but I did both in case that's what you'd want.

## Open Questions

It's possible it makes more sense to link to the file within lit-html's repo and not a specific line since that line reference is liable to become dead. If you know of a place this renderer is documented outside of the code I think it would also make sense to link there but I couldn't find one.
