### PR TITLE
renderer-react: wrap via asCustomElement

### DIFF
--- a/packages/renderer-react/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/renderer-react/src/__tests__/__snapshots__/index.js.snap
@@ -6,8 +6,6 @@ exports[`renders 2`] = `"<div data-reactroot=\\"\\"><!-- react-text: 2 -->Hello,
 
 exports[`renders 3`] = `"<div data-reactroot=\\"\\"><!-- react-text: 2 -->Hello, <!-- /react-text --><!-- react-text: 3 -->Bob<!-- /react-text --><!-- react-text: 4 -->!<!-- /react-text --></div>"`;
 
-exports[`wrapper - empty 1`] = `"<span data-reactroot=\\"\\"></span>"`;
-
 exports[`wrapper - override render() 1`] = `"<div data-reactroot=\\"\\"><!-- react-text: 2 -->Hello, <!-- /react-text --><slot></slot><!-- react-text: 4 -->!<!-- /react-text --></div>"`;
 
 exports[`wrapper - static component 1`] = `"<div data-reactroot=\\"\\"><!-- react-text: 2 -->Hello, <!-- /react-text --><slot></slot><!-- react-text: 4 -->!<!-- /react-text --></div>"`;

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { define } from 'skatejs';
-import withRenderer, { asCustomElement } from '..';
+import withRenderer, { wrap } from '..';
 
 function render(Comp) {
   const el = new Comp();
@@ -31,7 +31,7 @@ test('renders', () => {
 });
 
 test('wrapper - static component', () => {
-  const ReactComponentWrapper = asCustomElement(ReactComponent);
+  const ReactComponentWrapper = wrap(ReactComponent);
 
   define(ReactComponentWrapper);
   const el = render(ReactComponentWrapper);
@@ -40,7 +40,7 @@ test('wrapper - static component', () => {
 
 test('wrapper - override render()', () => {
   @define
-  class ReactComponentWrapper extends asCustomElement(ReactComponent) {
+  class ReactComponentWrapper extends wrap(ReactComponent) {
     render() {
       return <ReactComponent {...this.props} />;
     }

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -30,14 +30,6 @@ test('renders', () => {
   expect(el.innerHTML).toMatchSnapshot();
 });
 
-test('wrapper - empty', () => {
-  @define
-  class ReactComponentWrapper extends withRenderer() {}
-
-  const el = render(ReactComponentWrapper);
-  expect(el.innerHTML).toMatchSnapshot();
-});
-
 test('wrapper - static component', () => {
   const ReactComponentWrapper = asCustomElement(ReactComponent);
 

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { define } from 'skatejs';
-import withRenderer from '..';
+import withRenderer, { asCustomElement } from '..';
 
 function render(Comp) {
   const el = new Comp();
@@ -39,11 +39,9 @@ test('wrapper - empty', () => {
 });
 
 test('wrapper - static component', () => {
-  @define
-  class ReactComponentWrapper extends withRenderer() {
-    static component = ReactComponent;
-  }
+  const ReactComponentWrapper = asCustomElement(ReactComponent);
 
+  define(ReactComponentWrapper);
   const el = render(ReactComponentWrapper);
   expect(el.innerHTML).toMatchSnapshot();
 });

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -40,7 +40,7 @@ test('wrapper - static component', () => {
 
 test('wrapper - override render()', () => {
   @define
-  class ReactComponentWrapper extends withRenderer() {
+  class ReactComponentWrapper extends asCustomElement(ReactComponent) {
     render() {
       return <ReactComponent {...this.props} />;
     }

--- a/packages/renderer-react/src/index.js
+++ b/packages/renderer-react/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from 'react-dom';
+import { withRenderer } from 'skatejs';
 
-export default (Base = HTMLElement) =>
+const withReact = (Base = HTMLElement) =>
   class extends Base {
     get props() {
       // We override props so that we can satisfy most use
@@ -11,11 +12,16 @@ export default (Base = HTMLElement) =>
         ...{ children: <slot /> }
       };
     }
-    render() {
-      const Component = this.constructor.component;
-      return Component ? <Component {...this.props} /> : <span />;
-    }
     renderer(root, call) {
       render(call(), root);
+    }
+  };
+
+export default withReact;
+
+export const asCustomElement = Component =>
+  class extends withReact() {
+    render() {
+      return <Component {...this.props} />;
     }
   };

--- a/packages/renderer-react/src/index.js
+++ b/packages/renderer-react/src/index.js
@@ -19,7 +19,7 @@ const withReact = (Base = HTMLElement) =>
 
 export default withReact;
 
-export const asCustomElement = Component =>
+export const wrap = Component =>
   class extends withReact() {
     render() {
       return <Component {...this.props} />;


### PR DESCRIPTION
Per [this twitter thread](https://twitter.com/BedeOverend/status/941975889348214785), this PR explores wrapping React components via a separate function exported with `renderer-react`.

Instead of:

```js
import ReactComponent from 'a-react-component';
import withReact from '@skatejs/renderer-react';

export default class extends withReact() {
  static component = ReactComponent
}
```

usage would be:

```js
import ReactComponent from 'a-react-component';
import { asCustomElement } from '@skatejs/renderer-react';

export default asCustomElement(ReactComponent);
```

Currently it doesn't (as this PR just moves from static to an external function), but might be worth having `asCustomElement` export a fully fledged CustomElement that'll mimic the React component's lifecycle methods. I'm guessing for general support of this it'll need to export a class which uses `withUpdate` and `withRenderer`, that way when props update it'll actually trigger a render.

cc @treshugart thoughts?