### PR TITLE
chore(react): Updates peerDependencies to allow React 16

### DIFF
--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -26,8 +26,8 @@
   "module": "dist/es/index.js",
   "name": "@skatejs/renderer-react",
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "version": "0.2.0",
   "dependencies": {


### PR DESCRIPTION
* [x] Chore/Feature

## Rationale
Allows React 16 to be used without warnings
