### PR TITLE
Add to with-react renderer showing wrap usage. Fixes #1281

### DIFF
--- a/site/pages/renderers/__samples__/wrap-react.html
+++ b/site/pages/renderers/__samples__/wrap-react.html
@@ -1,0 +1,1 @@
+<wrap-react name="World"></wrap-react>

--- a/site/pages/renderers/__samples__/wrap-react.js
+++ b/site/pages/renderers/__samples__/wrap-react.js
@@ -1,0 +1,21 @@
+// @jsx React.createElement
+
+import { props, withComponent } from 'skatejs';
+import { wrap } from '@skatejs/renderer-react';
+import React from 'react';
+
+class HelloReact extends React.Component {
+  render() {
+    return <span>Hello, {this.props.name}!</span>;
+  }
+}
+
+class WrapReact extends withComponent(wrap(HelloReact)) {
+  static get props() {
+    return {
+      name: props.string
+    };
+  }
+}
+
+customElements.define('wrap-react', WrapReact);

--- a/site/pages/renderers/with-react.js
+++ b/site/pages/renderers/with-react.js
@@ -12,6 +12,10 @@ import './__samples__/with-react';
 import codeWithReact from '!raw-loader!./__samples__/with-react';
 import codeWithReactHtml from '!raw-loader!./__samples__/with-react.html';
 
+import './__samples__/wrap-react';
+import codeWrapReact from '!raw-loader!./__samples__/wrap-react';
+import codeWrapReactHtml from '!raw-loader!./__samples__/wrap-react.html';
+
 @define
 export default class extends Component {
   static is = 'x-pages-renderers-react';
@@ -27,6 +31,15 @@ export default class extends Component {
         <x-runnable
           code="${codeWithReact}"
           html="${codeWithReactHtml}"></x-runnable>
+
+        <p>
+          The React renderer also exports a <code>wrap</code> function
+          which takes a React component and returns a Custom Element which renders
+          the given React component on <code>render</code>
+        </p>
+        <x-runnable
+          code="${codeWrapReact}"
+          html="${codeWrapReactHtml}"></x-runnable>
       </x-layout>
     `;
   }


### PR DESCRIPTION
Adds documentation about the `wrap` function - it's pretty minimal, just showing that it exists and a _very_ basic example.

cc @treshugart 