### PR TITLE
Ssr improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "babel-register": "^6.26.0",
     "glob": "^7.1.2",
     "highlight.js": "^9.12.0",
-    "jest-environment-node": "^21.1.0",
+    "jest-environment-node": "^21.1.0 || ^22",
     "js-beautify": "^1.7.3",
     "lit-html": "^0.7.1",
     "marked": "^0.3.7",

--- a/packages/ssr/jest.js
+++ b/packages/ssr/jest.js
@@ -12,7 +12,14 @@ module.exports = class extends NodeEnvironment {
   setup() {
     return Promise.resolve();
   }
+
+  // Jest@21 uses `dispose` Jest@22 uses `teardown`.
+  // To support both we provide both.
+  // See the Jest@22 Changelog: https://github.com/facebook/jest/blob/master/CHANGELOG.md#features-3
   teardown() {
     return Promise.resolve();
+  }
+  dispose() {
+    return this.teardown();
   }
 };

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "babel-register": "^6.26.0",
     "glob": "^7.1.2",
-    "jest-environment-node": "^21.1.0",
+    "jest-environment-node": "^21.1.0 || ^22",
     "js-beautify": "^1.7.3",
     "mkdirp": "^0.5.1",
     "outdent": "^0.4.1",

--- a/packages/ssr/register/Node.js
+++ b/packages/ssr/register/Node.js
@@ -69,6 +69,34 @@ Object.defineProperty(NodeProto, 'textContent', {
   }
 });
 
+NodeProto.cloneNode = function(deep) {
+  let clone;
+  switch(this.nodeType) {
+    case Node.ELEMENT_NODE:
+      clone = document.createElement(this.nodeName);
+      clone.attributes = this.attributes.slice();
+      break;
+    case Node.DOCUMENT_FRAGMENT_NODE:
+      clone = document.createDocumentFragment();
+      break;
+    case Node.TEXT_NODE:
+      clone = document.createTextNode(this.textContent);
+      break;
+  }
+
+  if (!deep) {
+    return clone;
+  }
+
+  for (let childNode of this.childNodes) {
+    clone.childNodes.push(childNode.cloneNode(true));
+  }
+
+  clone.innerText = this.innerText;
+
+  return clone;
+}
+
 NodeProto.contains = function(node) {
   if (this === node) {
     return true;

--- a/packages/ssr/register/Node.js
+++ b/packages/ssr/register/Node.js
@@ -31,7 +31,11 @@ Object.defineProperty(NodeProto, 'content', {
   get() {
     if (!this._content) {
       this._content = new DocumentFragment();
-      this.childNodes.forEach(node => this._content.appendChild(node));
+      this.childNodes.forEach(node => {
+        node = node.cloneNode(true);
+        node.parentNode = this._content;
+        this._content.childNodes.push(node);
+      });
     }
     return this._content;
   }
@@ -71,7 +75,7 @@ Object.defineProperty(NodeProto, 'textContent', {
 
 NodeProto.cloneNode = function(deep) {
   let clone;
-  switch(this.nodeType) {
+  switch (this.nodeType) {
     case Node.ELEMENT_NODE:
       clone = document.createElement(this.nodeName);
       clone.attributes = this.attributes.slice();
@@ -95,7 +99,7 @@ NodeProto.cloneNode = function(deep) {
   clone.innerText = this.innerText;
 
   return clone;
-}
+};
 
 NodeProto.contains = function(node) {
   if (this === node) {

--- a/packages/ssr/test/Node.test.js
+++ b/packages/ssr/test/Node.test.js
@@ -35,4 +35,54 @@ describe('Node', () => {
 
     it('should connect a fragment of elements', () => {});
   });
+
+  describe('cloneNode', () => {
+    function testCloneEquality(source, clone, deeplyCloned) {
+      expect(clone.nodeName).toEqual(source.nodeName);
+
+      if (clone.attributes) {
+        clone.attributes.forEach(({ name, value }) =>
+          expect(value).toEqual(source.getAttribute(name))
+        );
+      }
+
+      expect(clone.nodeType).toEqual(source.nodeType);
+
+      if (deeplyCloned) {
+        expect(clone.textContent).toEqual(source.textContent);
+
+        expect(clone.childNodes.length).toEqual(source.childNodes.length);
+        if (clone.childNodes) {
+          clone.childNodes.forEach((child, i) => {
+            testCloneEquality(source.childNodes[i], child, true);
+          });
+        }
+      } else {
+        expect(clone.childNodes.length).toEqual(0);
+      }
+    }
+
+    beforeEach(() => {
+      const child = document.createElement('span');
+      child.setAttribute('clone-this', 'test');
+      child.appendChild(document.createTextNode('example text child'));
+      const grandchild = document.createElement('div');
+      grandchild.setAttribute('id', '42');
+      grandchild.appendChild(document.createTextNode('grandchild text node'));
+      child.appendChild(grandchild);
+
+      host.appendChild(child);
+      host.setAttribute('clone-this', 'test');
+    });
+
+    it('clones an element shallowly', () => {
+      const clone = host.cloneNode();
+      testCloneEquality(host, clone, false);
+    });
+
+    it('clones an element deeply', () => {
+      const clone = host.cloneNode(true);
+      testCloneEquality(host, clone, true);
+    });
+  });
 });

--- a/packages/ssr/test/Node.test.js
+++ b/packages/ssr/test/Node.test.js
@@ -85,4 +85,19 @@ describe('Node', () => {
       testCloneEquality(host, clone, true);
     });
   });
+
+  describe('content', () => {
+    it('should return a documentFragment containing all children', () => {
+      for (let i = 0; i < 10; i++) {
+        const child = document.createElement('span');
+        child.innerText = i;
+        host.appendChild(child);
+      }
+      const content = host.content;
+      expect(content.childNodes.length).toEqual(10);
+      for (let i = 0; i < 10; i++) {
+        expect(content.childNodes[i].innerText).toEqual(i);
+      }
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz#2349d7ec04b3a06945ae173280ef8579b63728e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 "@skatejs/bore@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@skatejs/bore/-/bore-4.0.1.tgz#8e101ac73bcc4df48f338e99ea7f40767768ca0f"
@@ -4106,7 +4114,14 @@ jest-environment-node@^20.0.3:
     jest-mock "^20.0.3"
     jest-util "^20.0.3"
 
-jest-environment-node@^21.1.0, jest-environment-node@^21.2.1:
+"jest-environment-node@^21.1.0 || ^22":
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.0.4.tgz#068671f85a545f96a5469be3a3dd228fca79c709"
+  dependencies:
+    jest-mock "^22.0.3"
+    jest-util "^22.0.4"
+
+jest-environment-node@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
   dependencies:
@@ -4116,6 +4131,10 @@ jest-environment-node@^21.1.0, jest-environment-node@^21.2.1:
 jest-get-type@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-get-type@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.0.3.tgz#fa894b677c0fcd55eff3fd8ee28c7be942e32d36"
 
 jest-haste-map@^20.0.4:
   version "20.0.5"
@@ -4210,6 +4229,16 @@ jest-message-util@^21.2.1:
     micromatch "^2.3.11"
     slash "^1.0.0"
 
+jest-message-util@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.0.3.tgz#bf674b2762ef2dd53facf2136423fcca264976df"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-20.0.3.tgz#8bc070e90414aa155c11a8d64c869a0d5c71da59"
@@ -4217,6 +4246,10 @@ jest-mock@^20.0.3:
 jest-mock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+
+jest-mock@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.0.3.tgz#c875e47b5b729c6c020a2fab317b275c0cf88961"
 
 jest-regex-util@^20.0.3:
   version "20.0.3"
@@ -4357,6 +4390,18 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
+jest-util@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.0.4.tgz#d920a513e0645aaab030cee38e4fe7d5bed8bb6d"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^22.0.3"
+    jest-validate "^22.0.3"
+    mkdirp "^0.5.1"
+
 jest-validate@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
@@ -4374,6 +4419,15 @@ jest-validate@^21.1.0, jest-validate@^21.2.1:
     jest-get-type "^21.2.0"
     leven "^2.1.0"
     pretty-format "^21.2.1"
+
+jest-validate@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.0.3.tgz#2850d949a36c48b1a40f7eebae1d8539126f7829"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.0.3"
+    leven "^2.1.0"
+    pretty-format "^22.0.3"
 
 jest@^20.0.4:
   version "20.0.4"
@@ -5639,6 +5693,13 @@ pretty-format@^21.2.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.0.3.tgz#a2bfa59fc33ad24aa4429981bb52524b41ba5dd7"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 prismjs@^1.8.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.8.4.tgz#573cc7a14c2c06566e1eca20d813f5ae55db80d2"
@@ -6490,6 +6551,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
 staged-git-files@0.0.4:
   version "0.0.4"


### PR DESCRIPTION

* [x] Fixes:#1285
* [x] Feature: Add `cloneNode`
* [x] Fixes broken `content`

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [x] Updated docs and upgrade instructions, if necessary.
* [x] Updated TS definitions, if necessary.

## Rationale

This PR does a few things let me know if you'd like me to break it up.

- Firstly this enables usage of either jest 21 or jest 22. This required an update to the `jest-environment-node` dep as well as working around a [breaking change](https://github.com/facebook/jest/blob/master/CHANGELOG.md#features-3).
- Secondly this adds a thin `cloneNode` implementation. This implementation *should* be sufficient for 99% of cases. I'm sure there are some edge cases where the duplication won't be sufficient however I don't know what those might be without doing more serious testing.
- Thirdly this fixes a bug with `.content` which was causing it to return an incomplete `documentFragment`. This is because `appendChild` disconnects the child from the parent. We don't want this behavior for 2 reasons:
  1. If you disconnect a child while iterating the list you'll fail to iterate the whole list.
  1. After using `content` the element will no longer have children.


## Implementation

`cloneNode` was implemented as faithfully as I could given the simplicity of undom. As mentioned above there's a few known oddities such as:

- `innerText` is copied as well as any actual text nodes. This is because `innerText` isn't actually handled in any particular way aside from being a static property. Unlike in a real DOM where `innerText` creates a text node child and replaces the content. Possibly this is something that should be added either in this or another PR.
- Given the few number of node types it's likely that there are specializations that are being missed here.

## Tasks

I've still got to update docs and the TS definitions.