### PR TITLE
Let users know which props changed (without looping)

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -82,6 +82,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _props: Object;
 
     _prevProps: Object;
+    _changedProps: Array<string>;
     _prevState: Object;
     _state: Object;
     _syncingAttributeToProperty: null | string;
@@ -96,6 +97,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
 
     static _observedAttributes = [];
     _prevProps = {};
+    _changedProps = [];
     _prevState = {};
     _state = {};
 
@@ -147,6 +149,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       if (super.attributeChangedCallback) {
         super.attributeChangedCallback(name, oldValue, newValue);
       }
+      if (!this._changedProps.includes(name)) this._changedProps.push(name)
       syncAttributeToProperty(this, name, newValue);
     }
 
@@ -167,15 +170,16 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       }
       this._updating = true;
       delay(() => {
-        const { _prevProps, _prevState } = this;
+        const { _prevProps, _prevState, _changedProps } = this;
         if (this.updating) {
-          this.updating(_prevProps, _prevState);
+          this.updating(_prevProps, _prevState, _changedProps);
         }
-        if (this.updated && this.shouldUpdate(_prevProps, _prevState)) {
-          this.updated(_prevProps, _prevState);
+        if (this.updated && this.shouldUpdate(_prevProps, _prevState, _changedProps)) {
+          this.updated(_prevProps, _prevState, _changedProps);
         }
         this._prevProps = this.props;
         this._prevState = this.state;
+        this._changedProps.length = 0;
         this._updating = false;
       });
     }

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -82,7 +82,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _props: Object;
 
     _prevProps: Object;
-    _changedProps: Array<string>;
+    _changedProps: Set<string>;
     _prevState: Object;
     _state: Object;
     _syncingAttributeToProperty: null | string;
@@ -97,7 +97,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
 
     static _observedAttributes = [];
     _prevProps = {};
-    _changedProps = [];
+    _changedProps = new Set;
     _prevState = {};
     _state = {};
 
@@ -149,7 +149,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       if (super.attributeChangedCallback) {
         super.attributeChangedCallback(name, oldValue, newValue);
       }
-      if (!this._changedProps.includes(name)) this._changedProps.push(name)
+      this._changedProps.add(name)
       syncAttributeToProperty(this, name, newValue);
     }
 
@@ -179,7 +179,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
         }
         this._prevProps = this.props;
         this._prevState = this.state;
-        this._changedProps.length = 0;
+        this._changedProps.clear();
         this._updating = false;
       });
     }


### PR DESCRIPTION
_If there is a linked issue, mention it here._

* [ ] Bug
* [x] Feature, https://github.com/skatejs/skatejs/issues/1318

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

_Why is this PR necessary?_

It gives the user a simple array to check which props were changed. This may prevent someone from instead relying on `attributeChangedCallback` which is not batched.

The user can then _optionally_ loop on the changed attributes.

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

I user an `Array` isntead of a `Set` because I didn't want to worry about TypeScript types, and plus it's probably faster. I'm setting `length = 0` instead of making a new array (avoiding GC).

## Open questions

_Are there any open questions about this implementation that need answers?_

Not yet.

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't
need it._

* [ ] If you're okay with the change, then I can finish the Requirements section (docs, tests, etc).
