### PR TITLE
tip about when to call super.updated

### DIFF
--- a/site/pages/mixins/with-renderer.js
+++ b/site/pages/mixins/with-renderer.js
@@ -36,6 +36,12 @@ export default class extends Component {
           For more information on how to write renderers, see the
           <x-link href="/renderers">Renderers</x-link> section.
         </p>
+        <p>
+          If you're using <code>withRenderer</code> along with <code>withUpdate</code>
+          and you give your class an <code>updated</code> method, you may want to call
+          <code>super.updated</code> last, so that you can process <code>this.props</code>
+          and <code>this.state</code> before rendering happens in the super call.
+        </p>
       </x-layout>
     `;
   }


### PR DESCRIPTION
This is just a doc update.

I added this because it may not be obvious, and people likely want to work with props and state before the new DOM is rendered.

Thoughts on this?