### PR TITLE
Fix "undefined" appearing in the DOM if component doesn't render anything

### DIFF
--- a/packages/skatejs/src/with-renderer.js
+++ b/packages/skatejs/src/with-renderer.js
@@ -14,7 +14,7 @@ export const withRenderer = (Base: Class<any> = HTMLElement): Class<any> =>
       if (super.renderer) {
         super.renderer(root, html);
       } else {
-        root.innerHTML = html();
+        root.innerHTML = html() || '';
       }
     }
 


### PR DESCRIPTION
_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [ ] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

_Why is this PR necessary?_

`undefined` appears in the DOM if the element doesn't render anything (f.e. the call to `() => this.render && this.render(this)` in the `updated` method returns `undefined` when there's no `render` method).

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

The `||` check replaces the `undefined` with an empty string.

## Open questions

_Are there any open questions about this implementation that need answers?_


## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't
need it._

* [ ] write a test
