### PR TITLE
IE11 fix for preact renderer

### DIFF
--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -13,8 +13,6 @@ export default (Base = HTMLElement) =>
       };
     }
     renderer(root, call) {
-      const children = root.children ||
-        [].map.call(root.childNodes, node => node.nodeType === 1);
-      this._preactDom = render(call(), root, this._preactDom || children[0]);
+      this._preactDom = render(call(), root, this._preactDom || root.childNodes[0]);
     }
   };

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -13,8 +13,7 @@ export default (Base = HTMLElement) =>
       };
     }
     renderer(root, call) {
-      const children =
-        root.children ||
+      const children = root.children ||
         [].map.call(root.childNodes, node => node.nodeType === 1);
       this._preactDom = render(call(), root, this._preactDom || children[0]);
     }

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -13,10 +13,9 @@ export default (Base = HTMLElement) =>
       };
     }
     renderer(root, call) {
-      this._preactDom = render(
-        call(),
-        root,
-        this._preactDom || root.children[0]
-      );
+      const children =
+        root.children ||
+        [].map.call(root.childNodes, node => node.nodeType === 1);
+      this._preactDom = render(call(), root, this._preactDom || children[0]);
     }
   };

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -13,6 +13,10 @@ export default (Base = HTMLElement) =>
       };
     }
     renderer(root, call) {
-      this._preactDom = render(call(), root, this._preactDom || root.childNodes[0]);
+      this._preactDom = render(
+        call(),
+        root,
+        this._preactDom || root.childNodes[0]
+      );
     }
   };


### PR DESCRIPTION
## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

Preact Renderer does not work in IE11.

## Implementation

`children` is not supported in IE11, falling back to `childNodes` instead.