### PR TITLE
make `npm install` work

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "dev": "cd site && webpack-dev-server --hot",
     "flow": "flow",
     "precommit": "lint-staged",
-    "prepare": "bolt build",
+    "prepare": "yarn build",
     "site": "cd site && webpack -p",
     "test": "jest"
   },


### PR DESCRIPTION
_If there is a linked issue, mention it here._

* [ ] Bug
* [ ] Feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

This makes `npm install` work with a fresh clone of the repo, otherwise it fails with an error like the following error. Now anyone using NPM can install and run the various scripts.

```
skatejs+skatejs git:master ❯ npm i

> skatejs-monorepo@ prepare /home/trusktr/Downloads/src/skatejs+skatejs
> bolt build

⚡️   bolt v0.19.2 (node v8.5.0)
$ projector ./projector babel --envs es,esnext,node
/bin/sh: 1: node_modules/bolt/node_modules/.bin/yarn: not found
error Error
error     at ChildProcess.child.on.code (/home/trusktr/Downloads/src/skatejs+skatejs/node_modules/bolt/dist/modern/utils/processes.js:115:16)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! skatejs-monorepo@ prepare: `bolt build`
npm ERR! Exit status 1
```

## Implementation

I changed `bolt build` to `yarn build`, which works, and seems to do the same thing.

## Open questions

Does `yarn build` in fact accomplish the same thing, or do we really need `bolt build` there?