### PR TITLE
Compatibility with babel-transform-builtin-classes

### DIFF
--- a/packages/renderer-lit-html/src/index.js
+++ b/packages/renderer-lit-html/src/index.js
@@ -1,6 +1,6 @@
 import { render } from 'lit-html/lib/lit-extended';
 
-export default (Base = HTMLElement) =>
+export default (Base = class extends HTMLElement {}) =>
   class extends Base {
     renderer(root, call) {
       render(call(), root);


### PR DESCRIPTION
This is an incomplete pull request. It just shows how to make the lib compatible with babel-plugin-transform-builtin-classes (and therefore not require `webcomponentsjs`'s adapter).

This would need to be applied anywhere else that a native classes is being used.

What this does is enable transform-builtin-classes to work (it reads the class syntax), so that it will be able to patch the native extension.

End users will still have to configure the plugin to look for `HTMLElement`, and other native classes. We could also supply an example babelrc in this repo.

I haven't checked, but if all uses of the native class can be supplied from the end user, then it might not be necessary.

So, just opening this here in case it is helpful, but not sure if you actually want to do all these changes.

---

Also note, Babel 7 will [include this transform builtin](https://github.com/babel/babel/pull/7020), but at the moment it [doesn't work](https://github.com/babel/babel/pull/7020#issuecomment-362113864), or at least, there's no indication of what I have to do to make it work.