### PR TITLE
Add a withInitializer mixin to allow one-time setup of components after they are defined 

### DIFF
--- a/packages/skatejs/src/index.js
+++ b/packages/skatejs/src/index.js
@@ -8,6 +8,7 @@ export * from './shadow.js';
 export * from './with-children.js';
 export * from './with-context.js';
 export * from './with-component.js';
+export * from './with-initializer.js';
 export * from './with-lifecycle.js';
 export * from './with-update.js';
 export * from './with-renderer.js';

--- a/packages/skatejs/src/with-initializer.js
+++ b/packages/skatejs/src/with-initializer.js
@@ -3,8 +3,9 @@
 export const withInitializer = (Base: Class<any> = HTMLElement): Class<any> =>
   class extends Base {
     static get observedAttributes() {
-      super.observedAttributes && super.observedAttributes();
+      let observed = super.observedAttributes;
       this.initializeCallback();
+      return observed;
     }
     static initializeCallback() {
       super.initializeCallback && super.initializeCallback();

--- a/packages/skatejs/src/with-initializer.js
+++ b/packages/skatejs/src/with-initializer.js
@@ -2,11 +2,11 @@
 
 export const withInitializer = (Base: Class<any> = HTMLElement): Class<any> =>
   class extends Base {
-    constructor() {
-      super();
+    static get observedAttributes() {
+      super.observedAttributes && super.observedAttributes();
       this.initializeCallback();
     }
-    initializeCallback() {
+    static initializeCallback() {
       super.initializeCallback && super.initializeCallback();
     }
   };

--- a/packages/skatejs/src/with-initializer.js
+++ b/packages/skatejs/src/with-initializer.js
@@ -1,0 +1,12 @@
+// @flow
+
+export const withInitializer = (Base: Class<any> = HTMLElement): Class<any> =>
+  class extends Base {
+    constructor() {
+      super();
+      this.initializeCallback();
+    }
+    initializeCallback() {
+      super.initializeCallback && super.initializeCallback();
+    }
+  };

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -148,7 +148,10 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     _state = {};
 
     static get observedAttributes(): Array<string> {
-      super.observedAttributes && super.observedAttributes();
+      let observed = super.observedAttributes && super.observedAttributes();
+      if (observed) {
+        this._observedAttributes = this._observedAttributes.concat(observed);
+      }
       // We have to define props here because observedAttributes are retrieved
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -148,6 +148,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     _state = {};
 
     static get observedAttributes(): Array<string> {
+      super.observedAttributes && super.observedAttributes();
       // We have to define props here because observedAttributes are retrieved
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.

--- a/packages/skatejs/test/unit/with-initializer.spec.js
+++ b/packages/skatejs/test/unit/with-initializer.spec.js
@@ -12,18 +12,44 @@ const NamedTest = define(
 
 describe('withInitializer', () => {
   describe('initializeCallback()', () => {
-    const Elem = define(
-      class extends UnnamedTest {
-        initializeCallback() {}
-      }
-    );
+    let counter;
+    let Elem;
 
-    it('is called when an element is created', done => {
-      const spy = jest.spyOn(Elem.prototype, 'initializeCallback');
+    beforeEach(() => {
+      counter = 0;
+      Elem = class extends UnnamedTest {
+        static initializeCallback() {
+          ++counter;
+        }
+      };
+    });
+
+    it('is called when an element definition is registered', () => {
+      expect(counter).toEqual(0);
+      define(Elem);
+      expect(counter).toEqual(1);
+    });
+
+    it('is not called when an individual element is constructed', () => {
+      define(Elem);
+      expect(counter).toEqual(1);
       mount(new Elem());
-      setTimeout(() => {
-        expect(spy).toBeCalled();
-        done();
+      mount(new Elem());
+      expect(counter).toEqual(1);
+    });
+
+    describe('on named elements', () => {
+      beforeEach(() => {
+        Elem = class extends NamedTest {
+          static initializeCallback() {
+            ++counter;
+          }
+        };
+      });
+
+      it('is called when an element definition is registered', () => {
+        define(Elem);
+        expect(counter).toEqual(1);
       });
     });
   });

--- a/packages/skatejs/test/unit/with-initializer.spec.js
+++ b/packages/skatejs/test/unit/with-initializer.spec.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { mount } from '@skatejs/bore';
+import { define, name, withInitializer } from '../../src';
+
+const UnnamedTest = define(class extends withInitializer() {});
+const NamedTest = define(
+  class extends withInitializer() {
+    static is = name();
+  }
+);
+
+describe('withInitializer', () => {
+  describe('initializeCallback()', () => {
+    const Elem = define(
+      class extends UnnamedTest {
+        initializeCallback() {}
+      }
+    );
+
+    it('is called when an element is created', done => {
+      const spy = jest.spyOn(Elem.prototype, 'initializeCallback');
+      mount(new Elem());
+      setTimeout(() => {
+        expect(spy).toBeCalled();
+        done();
+      });
+    });
+  });
+});

--- a/packages/skatejs/test/unit/with-initializer.spec.js
+++ b/packages/skatejs/test/unit/with-initializer.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { mount } from '@skatejs/bore';
-import { define, name, withInitializer } from '../../src';
+import { define, name, props, withInitializer, withUpdate } from '../../src';
 
 const UnnamedTest = define(class extends withInitializer() {});
 const NamedTest = define(
@@ -49,6 +49,23 @@ describe('withInitializer', () => {
 
       it('is called when an element definition is registered', () => {
         define(Elem);
+        expect(counter).toEqual(1);
+      });
+    });
+
+    describe('implementation details', () => {
+      it('works with the withUpdate mixin', () => {
+        const UpdatingElem = class extends withUpdate(Elem) {
+          static get props() {
+            return {
+              name: props.string
+            };
+          }
+          updated() {
+            return (shadow(this).innerHTML = `Hello, ${this.name}!`);
+          }
+        };
+        define(UpdatingElem);
         expect(counter).toEqual(1);
       });
     });

--- a/packages/skatejs/test/unit/with-initializer.spec.js
+++ b/packages/skatejs/test/unit/with-initializer.spec.js
@@ -62,6 +62,21 @@ describe('withInitializer', () => {
         expect(counter).toEqual(1);
         expect(UpdatingElem.observedAttributes).toContain('name');
       });
+
+      it('works when withUpdate() wraps it', () => {
+        const UpdatingElem = class extends withInitializer(withUpdate()) {
+          static initializeCallback = inc;
+          static get props() {
+            return {
+              name: props.string
+            };
+          }
+        };
+        expect(counter).toEqual(0);
+        define(UpdatingElem);
+        expect(counter).toEqual(1);
+        expect(UpdatingElem.observedAttributes).toContain('name');
+      });
     });
   });
 });

--- a/packages/skatejs/test/unit/with-update.spec.js
+++ b/packages/skatejs/test/unit/with-update.spec.js
@@ -488,4 +488,19 @@ describe('state', () => {
     test.state = {};
     expect(updated).toBe(true);
   });
+
+  describe('inherited', () => {
+    let vals;
+    const Base = class extends HTMLElement {
+      static observedAttributes() {
+        return vals;
+      }
+    };
+
+    it('should inherit non-empty observedAttributes from the superclass', () => {
+      vals = ['thing'];
+      const Elem = class extends withUpdate(Base) {};
+      expect(Elem.observedAttributes).toContain('thing');
+    });
+  });
 });


### PR DESCRIPTION
Based on a twitter exchange: https://twitter.com/treshugart/status/965907794556678144

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

A change like this allows component authors to perform one-time setup work once their components have been defined by the browser, without having to know the element's name ahead of time.

## Implementation

We're exploiting the nature of how the `observedAttributes` method is invoked by browsers upon custom elements being registered.

Future implementations could be made more robust if we switched behaviour based on the presence of an `is` attribute; in that case we could call `customElements.whenDefined` directly and avoid this little exploit.

## Open questions

I'm not sure how sensible this is. I have a few conversation points:

* [ ] Is `withInitializer` and `initializeCallback` a sensible name? What others might make more sense?
* [x] Decide how `withUpdate` should interact with the return value of the `observedAttributes` method defined by `withInitializer`, if it needs to at all.
* [ ] Decide whether an addition of a naked `observedAttributes` method to a custom element class extended from `withInitializer` should work if they don't call `super.observedAttributes()`.

## Tasks

* [ ] Review the way elements are defined in tests; decide if they reasonably cover the real world.
* [ ] Add a working example to the docs, ideally based off of a real-world use-case.