### PR TITLE
Ensure the (p)react renderers do not hold on to renderRoot post disco…

### DIFF
--- a/packages/renderer-preact/src/__tests__/index.js
+++ b/packages/renderer-preact/src/__tests__/index.js
@@ -74,5 +74,6 @@ test('wrappers cleanup', () => {
   root.removeChild(el);
 
   expect(el.innerHTML).toMatchSnapshot();
+  expect(el._renderRoot).toBeNull();
   expect(willUnmountSpy).toHaveBeenCalled();
 });

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -25,5 +25,6 @@ export default (Base = HTMLElement) =>
       // Preact hack https://github.com/developit/preact/issues/53
       const Nothing = () => null;
       this._preactDom = render(<Nothing />, this._renderRoot, this._preactDom);
+      this._renderRoot = null;
     }
   };

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -88,6 +88,7 @@ test('unmounts', () => {
   container.removeChild(el);
 
   expect(el.firstChild).toBeNull();
+  expect(el._renderRoot).toBeNull();
   expect(mockMount).toHaveBeenCalledTimes(1);
   expect(mockUnmount).toHaveBeenCalledTimes(1);
 });

--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "dependencies": {
     "@skatejs/renderer-lit-html": "0.2.0",
-    "@skatejs/renderer-preact": "0.2.5",
-    "@skatejs/renderer-react": "0.2.1",
+    "@skatejs/renderer-preact": "0.3.0",
+    "@skatejs/renderer-react": "0.3.0",
     "@skatejs/sk-marked": "0.0.0",
     "@skatejs/sk-router": "0.2.0",
     "highlight.js": "9.12.0",


### PR DESCRIPTION
…nnect.

See https://github.com/skatejs/skatejs/pull/1432#discussion_r183269151

_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [ ] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

_Why is this PR necessary?_
I think it's generally a good idea to null out any references after you're done using them, especially if they're DOM element references, to avoid any memory leaks.

## Implementation

_Why have you implemented it this way? Did you try any other methods?_
