### PR TITLE
Ensure the (p)react renderers do not hold on to renderRoot post disco…

### DIFF
--- a/packages/renderer-preact/src/__tests__/index.js
+++ b/packages/renderer-preact/src/__tests__/index.js
@@ -74,5 +74,6 @@ test('wrappers cleanup', () => {
   root.removeChild(el);
 
   expect(el.innerHTML).toMatchSnapshot();
+  expect(el._renderRoot).toBeNull();
   expect(willUnmountSpy).toHaveBeenCalled();
 });

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -25,5 +25,6 @@ export default (Base = HTMLElement) =>
       // Preact hack https://github.com/developit/preact/issues/53
       const Nothing = () => null;
       this._preactDom = render(<Nothing />, this._renderRoot, this._preactDom);
+      this._renderRoot = null;
     }
   };

--- a/packages/renderer-react/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/renderer-react/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`re-connecting & disconnecting without rendering works 1`] = `"<div data-reactroot=\\"\\"></div>"`;
+
+exports[`rendering after re-connecting works 1`] = `"<div data-reactroot=\\"\\"></div>"`;
+
+exports[`rendering after re-connecting works 2`] = `"<div data-reactroot=\\"\\"></div>"`;
+
 exports[`renders 1`] = `""`;
 
 exports[`renders 2`] = `"<div data-reactroot=\\"\\"><!-- react-text: 2 -->Hello, <!-- /react-text --><!-- react-text: 3 -->World<!-- /react-text --><!-- react-text: 4 -->!<!-- /react-text --></div>"`;

--- a/packages/renderer-react/src/__tests__/index.js
+++ b/packages/renderer-react/src/__tests__/index.js
@@ -88,6 +88,109 @@ test('unmounts', () => {
   container.removeChild(el);
 
   expect(el.firstChild).toBeNull();
+  expect(el._renderRoot).toBeNull();
   expect(mockMount).toHaveBeenCalledTimes(1);
   expect(mockUnmount).toHaveBeenCalledTimes(1);
+});
+
+test('re-connecting & disconnecting without rendering works', () => {
+  const container = document.createElement('div');
+
+  const mockMount = jest.fn();
+  const mockUnmount = jest.fn();
+
+  class MockReactComponent extends Component {
+    componentDidMount = mockMount;
+    componentWillUnmount = mockUnmount;
+    render() {
+      return <div />;
+    }
+  }
+
+  const ReactComponentWrapper = wrap(MockReactComponent);
+  define(ReactComponentWrapper);
+
+  expect(mockMount).toHaveBeenCalledTimes(0);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  const el = new ReactComponentWrapper();
+  container.appendChild(el);
+
+  expect(mockMount).toHaveBeenCalledTimes(0);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  el.renderer(el, el.render.bind(el));
+
+  expect(el.innerHTML).toMatchSnapshot();
+  expect(mockMount).toHaveBeenCalledTimes(1);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  container.removeChild(el);
+
+  expect(el.firstChild).toBeNull();
+  expect(el._renderRoot).toBeNull();
+  expect(mockMount).toHaveBeenCalledTimes(1);
+  expect(mockUnmount).toHaveBeenCalledTimes(1);
+
+  // Re-connect
+  container.appendChild(el);
+
+  // Disconnect without having rendered
+  expect(() => container.removeChild(el)).not.toThrow();
+});
+
+test('rendering after re-connecting works', () => {
+  const container = document.createElement('div');
+
+  const mockMount = jest.fn();
+  const mockUnmount = jest.fn();
+
+  class MockReactComponent extends Component {
+    componentDidMount = mockMount;
+    componentWillUnmount = mockUnmount;
+    render() {
+      return <div />;
+    }
+  }
+
+  const ReactComponentWrapper = wrap(MockReactComponent);
+  define(ReactComponentWrapper);
+
+  expect(mockMount).toHaveBeenCalledTimes(0);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  const el = new ReactComponentWrapper();
+  container.appendChild(el);
+
+  expect(mockMount).toHaveBeenCalledTimes(0);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  el.renderer(el, el.render.bind(el));
+
+  expect(el.innerHTML).toMatchSnapshot();
+  expect(mockMount).toHaveBeenCalledTimes(1);
+  expect(mockUnmount).toHaveBeenCalledTimes(0);
+
+  container.removeChild(el);
+
+  expect(el.firstChild).toBeNull();
+  expect(el._renderRoot).toBeNull();
+  expect(mockMount).toHaveBeenCalledTimes(1);
+  expect(mockUnmount).toHaveBeenCalledTimes(1);
+
+  // Re-connect
+  container.appendChild(el);
+
+  el.renderer(el, el.render.bind(el));
+
+  expect(el.innerHTML).toMatchSnapshot();
+  expect(mockMount).toHaveBeenCalledTimes(2);
+  expect(mockUnmount).toHaveBeenCalledTimes(1);
+
+  container.removeChild(el);
+
+  expect(el.firstChild).toBeNull();
+  expect(el._renderRoot).toBeNull();
+  expect(mockMount).toHaveBeenCalledTimes(2);
+  expect(mockUnmount).toHaveBeenCalledTimes(2);
 });

--- a/packages/renderer-react/src/index.js
+++ b/packages/renderer-react/src/index.js
@@ -17,8 +17,10 @@ const withReact = (Base = HTMLElement) =>
     }
     disconnectedCallback() {
       super.disconnectedCallback && super.disconnectedCallback();
-      unmountComponentAtNode(this._renderRoot);
-      this._renderRoot = null;
+      if (this._renderRoot) {
+        unmountComponentAtNode(this._renderRoot);
+        this._renderRoot = null;
+      }
     }
   };
 

--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "dependencies": {
     "@skatejs/renderer-lit-html": "0.2.0",
-    "@skatejs/renderer-preact": "0.2.5",
-    "@skatejs/renderer-react": "0.2.1",
+    "@skatejs/renderer-preact": "0.3.0",
+    "@skatejs/renderer-react": "0.3.0",
     "@skatejs/sk-marked": "0.0.0",
     "@skatejs/sk-router": "0.2.0",
     "highlight.js": "9.12.0",


### PR DESCRIPTION
…nnect.

See https://github.com/skatejs/skatejs/pull/1432#discussion_r183269151

Supersedes #1433 (didn't realise force pushing prevented PRs from reopening)

_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

_Why is this PR necessary?_

I think it's generally a good idea to null out any references after you're done using them, especially if they're DOM element references, to avoid any memory leaks.

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

Had to add a guard in the React renderer - otherwise the new `re-connecting & disconnecting without rendering` test case fails.

## Open questions

_Are there any open questions about this implementation that need answers?_

Decided to experiment with re-mounting using the Preact renderer and ran into issues (see https://github.com/NMinhNguyen/skatejs/commit/cc577bc382d93bd62543e02f818c7ecfbb3207ae#r28691709) whereby `el.innerHTML` doesn't update after a re-mount 😕 It is very likely to do with the "unmounting hack" introduced in https://github.com/skatejs/skatejs/commit/2de8a547ffb15c1c1987a2c37e5d7a7e85652886. That said, similar tests for the React renderer seem to pass. Gonna have to investigate what's going on in the Preact case.