### PR TITLE
Simplify unmounting Preact components.

### DIFF
--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -22,9 +22,8 @@ export default (Base = HTMLElement) =>
     }
     disconnectedCallback() {
       super.disconnectedCallback && super.disconnectedCallback();
-      // Preact hack https://github.com/developit/preact/issues/53
-      const Nothing = () => null;
-      this._preactDom = render(<Nothing />, this._renderRoot, this._preactDom);
+      // Render null to unmount. See https://github.com/skatejs/skatejs/pull/1432#discussion_r183381359
+      this._preactDom = render(null, this._renderRoot, this._preactDom);
       this._renderRoot = null;
     }
   };


### PR DESCRIPTION
See https://github.com/skatejs/skatejs/pull/1432#discussion_r183381359

_If there is a linked issue, mention it here._

* [ ] Bug
* [ ] Feature
* [x] Refactor of an existing feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests (this is a refactor change, so covered by existing ones).
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

_Why is this PR necessary?_

Makes unmounting Preact components simpler.

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

Locally, I also downgraded `preact` to 8.2.5, the lowest supported version as specified in the Preact renderer's `peerDependencies`, and this change still worked, so I think we should be safe :)
