### PR TITLE
ssr: fix setting textContent when node has child nodes

### DIFF
--- a/packages/ssr/register/Node.js
+++ b/packages/ssr/register/Node.js
@@ -99,6 +99,9 @@ prop(NodeProto, 'textContent', {
     return this.childNodes.map(c => c.nodeValue).join('');
   },
   set(val) {
+    while (this.firstChild) {
+      this.removeChild(this.firstChild);
+    }
     this.appendChild(document.createTextNode(val));
     if (this.nodeName === 'SCRIPT') {
       execCode(val);

--- a/packages/ssr/test/Node.test.js
+++ b/packages/ssr/test/Node.test.js
@@ -100,4 +100,24 @@ describe('Node', () => {
       }
     });
   });
+
+  describe('textContent', () => {
+    it('should get textContent', () => {
+      const text = 'Hello Bob!';
+      const div = document.createElement('div');
+      div.appendChild(document.createTextNode(text));
+      expect(div.textContent).toEqual(text);
+    });
+
+    it('should set textContent', () => {
+      const div = document.createElement('div');
+      const text = `Hello World!`;
+      div.textContent = text;
+      expect(div.textContent).toEqual(text);
+
+      const newText = `Hello Bob!`;
+      div.textContent = newText;
+      expect(div.textContent).toEqual(newText);
+    });
+  });
 });


### PR DESCRIPTION
* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the
      [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.
* [ ] Updated TS definitions, if necessary.

## Rationale

When a html node already has content (child nodes), textContent is appending the text instead of replacing

## Implementation

It removes the child nodes before adding the new one