### PR TITLE
Allow for a range of recent bolt cli clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     }
   },
   "bolt": {
-    "version": "^0.19.0",
+    "version": "0.18.0 - 0.21.0",
     "workspaces": [
       "site",
       "packages/*"


### PR DESCRIPTION
Globally installed package versions will vary. Unless version ^0.19.0 is required, this PR relaxes the mandatory range to 0.18.0 <= x <= 0.21.0. This allows for the use of the current version of bolt (0.20.7)

* [ :-1: ] Bug
* [ :+1: ] Feature

## Requirements

* [:+1:] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ :-1: ] Wrote tests. 

Manually tested: 
* `npm install -g bolt@^0.18.0`, `bolt`, and `npm test` (0.18.4)
* `npm install -g bolt@^0.19.0`, `bolt`, and `npm test` (0.19.3)
* `npm install -g bolt@^0.20.0`, `bolt`, and `npm test` (0.20.7)

* [ :+1: ] Updated docs and upgrade instructions, if necessary.

## Rationale

Not necessary, but nice to support a range of clients if they all work.

## Implementation

Read some chatter about bolt becoming a package level dependency rather than a global, so this PR may prove redundant.
