### PR TITLE
renderer-preact: fix caching of auto defined elements

### DIFF
--- a/packages/renderer-preact/src/__tests__/component-as-name.js
+++ b/packages/renderer-preact/src/__tests__/component-as-name.js
@@ -4,20 +4,21 @@ import { h } from 'preact';
 import { withComponent } from 'skatejs';
 import withRenderer from '..';
 
-class Comp1 extends withComponent(withRenderer()) {
+class MainComp extends withComponent(withRenderer()) {
   render() {
     return (
       <div>
         Hello,{' '}
-        <Comp2>
+        <ChildComp>
           <slot />
-        </Comp2>!
+        </ChildComp>
+        <ChildComp />
       </div>
     );
   }
 }
 
-class Comp2 extends withComponent(withRenderer()) {
+class ChildComp extends withComponent(withRenderer()) {
   render() {
     return (
       <b>
@@ -28,11 +29,13 @@ class Comp2 extends withComponent(withRenderer()) {
 }
 
 test('component as tag name / auto-defining', done => {
-  const comp1 = new Comp1();
-  document.body.appendChild(comp1);
+  const mainComp = new MainComp();
+  document.body.appendChild(mainComp);
   setTimeout(() => {
-    const comp2 = comp1.shadowRoot.children[0].children[0];
-    expect(comp2.nodeName).toMatch(new RegExp('^x-comp2'));
+    const childComp1 = mainComp.shadowRoot.children[0].children[0];
+    expect(childComp1.nodeName).toMatch(new RegExp('^child-comp'));
+    const childComp2 = mainComp.shadowRoot.children[0].children[1];
+    expect(childComp2.nodeName).toBe(childComp1.nodeName);
     done();
   });
 });

--- a/packages/renderer-preact/src/index.js
+++ b/packages/renderer-preact/src/index.js
@@ -13,8 +13,10 @@ function newVnode(vnode) {
   if (fn && fn.prototype instanceof HTMLElement) {
     if (!fn[preactNodeName]) {
       const prefix = fn.name;
-      fn = class extends fn {};
-      customElements.define((fn[preactNodeName] = name(prefix)), fn);
+      customElements.define(
+        (fn[preactNodeName] = name(prefix)),
+        class extends fn {}
+      );
     }
     vnode.nodeName = fn[preactNodeName];
   }


### PR DESCRIPTION
_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

A new component was being defined every time a component constructor was rendered

## Implementation

Set preactNodeName prop to the actual constructor and not the descendant

## Other

Renamed test components to more descriptive names