### PR TITLE
fix(ssr): assign document.defaultView to window (#1449)

### DIFF
--- a/packages/ssr/register/document.js
+++ b/packages/ssr/register/document.js
@@ -5,6 +5,8 @@ const { find, nodeName } = require('./util');
 
 const createElement = document.createElement.bind(document);
 
+document.defaultView = window;
+
 document.createComment = function(textContent) {
   const comment = new Comment();
   comment.textContent = textContent;


### PR DESCRIPTION
Fixes #1449 
* [X] Bug
* [ ] Feature

## Requirements

* [X] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [X] Wrote tests.
* [X] Updated docs and upgrade instructions, if necessary.

## Rationale
Fixes #1449 

## Implementation
simply adds an assignment in `ssr/register/document.js`

_motivation_
because the `window` returned from `undom` is not actually a DOM API window, the `skatejs/ssr/registry` takes over and corrects the DOM API.  As per the issue description
`document.defaultView === window` should always be true.  This breaks an implementation wrapping Material UI `^1.0.0` because a function checks the `ownerDocument` for `defaultView` on `componentDidMount` 
## Open questions
I would be happy to add tests but I'm not sure where to add this.
