### PR TITLE
Allow to define prop type using native types constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Skate is a functional abstraction over
 [the web component standards](https://github.com/w3c/webcomponents) that:
 
 * Produces cross-framework compatible components.
-* Abstracts away common attribute / property semantics via `props`, such as
+* Abstracts away common attribute / property semantics via `props` or native types, such as
   attribute reflection and coercion.
 * Adds several lifecycle callbacks for responding to prop updates, rendering and
   updating, as well as a way to manage internal component state.
@@ -60,7 +60,7 @@ import { h } from 'preact';
 class WithPreact extends withComponent(withPreact()) {
   static get props() {
     return {
-      name: props.string
+      name: props.string // String could be used also to define the prop type
     };
   }
   render({ name }) {

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -53,7 +53,7 @@ function defineProps(constructor) {
   if (constructor.hasOwnProperty('_propsNormalised')) return;
   const { props } = constructor;
   keys(props).forEach(name => {
-    let func = props[name];
+    let func = props[name] || props.any;
     if (defaultTypesMap.has(func)) func = defaultTypesMap.get(func);
     if (typeof func !== 'function') func = prop((func: any));
     func({ constructor }, name);

--- a/packages/skatejs/test/unit/with-update.spec.js
+++ b/packages/skatejs/test/unit/with-update.spec.js
@@ -86,6 +86,41 @@ test('static get props() {} should define observedAttributes', () => {
   expect(Test.observedAttributes.indexOf('test')).toBe(0);
 });
 
+function comparePropTypes(type1, type2) {
+  expect(type1.coerce).toEqual(type2.coerce);
+  expect(type1.serialize).toEqual(type2.serialize);
+  expect(type1.deserialize).toEqual(type2.deserialize);
+  expect(type1.default).toEqual(type2.default);
+}
+
+test('prop types could be defined with native types constructors', () => {
+  @define
+  class Test extends withUpdate() {
+    static get props() {
+      return {
+        propsString: props.string,
+        nativeString: String,
+        propsBoolean: props.boolean,
+        nativeBoolean: Boolean,
+        propsNumber: props.number,
+        nativeNumber: Number,
+        propsArray: props.array,
+        nativeArray: Array,
+        propsObject: props.object,
+        nativeObject: Object
+      };
+    }
+  }
+  const testEl = new Test();
+  const propsNormalised = testEl.constructor._propsNormalised;
+
+  comparePropTypes(propsNormalised.nativeString, propsNormalised.propsString);
+  comparePropTypes(propsNormalised.nativeBoolean, propsNormalised.propsBoolean);
+  comparePropTypes(propsNormalised.nativeNumber, propsNormalised.propsNumber);
+  comparePropTypes(propsNormalised.nativeObject, propsNormalised.propsObject);
+  comparePropTypes(propsNormalised.nativeArray, propsNormalised.propsArray);
+});
+
 describe('withUpdate', () => {
   it('should not share _props instance', () => {
     class Test1 extends withUpdate() {

--- a/packages/skatejs/test/unit/with-update.spec.js
+++ b/packages/skatejs/test/unit/with-update.spec.js
@@ -98,6 +98,9 @@ test('prop types could be defined with native types constructors', () => {
   class Test extends withUpdate() {
     static get props() {
       return {
+        propsAny: props.any,
+        nativeNull: null,
+        nativeUndefined: undefined,
         propsString: props.string,
         nativeString: String,
         propsBoolean: props.boolean,
@@ -114,6 +117,8 @@ test('prop types could be defined with native types constructors', () => {
   const testEl = new Test();
   const propsNormalised = testEl.constructor._propsNormalised;
 
+  comparePropTypes(propsNormalised.nativeNull, propsNormalised.propsAny);
+  comparePropTypes(propsNormalised.nativeUndefined, propsNormalised.propsAny);
   comparePropTypes(propsNormalised.nativeString, propsNormalised.propsString);
   comparePropTypes(propsNormalised.nativeBoolean, propsNormalised.propsBoolean);
   comparePropTypes(propsNormalised.nativeNumber, propsNormalised.propsNumber);

--- a/site/pages/mixins/with-update.js
+++ b/site/pages/mixins/with-update.js
@@ -158,33 +158,34 @@ export default class extends Component {
           ### Built-in props
 
           Skate ships with several built-in props that solve many of the common situations that you'll encounter.
+          They can be used through \`props\` namespace or its corresponding native type, e.g., \`props.array\` or \`Array\`
 
           All built-in props exhibint the following behaviour with attributes:
 
           1. They're linked to an attribute that has the same name as the property, but dash-cased.
           2. Attribute binding is one-way: attribute updates affect the property, but not the other way around.
 
-          #### any
+          #### props.any / undefined / null
 
           This provides you a way to have the default prop behaviour while allowing any value to come in.
 
-          #### array
+          #### props.array / Array
 
           The \`array\` prop ensures that whatever is passed to the prop is coerced to an array. This means that a string would be made into an array where it is the only item in the array. When linked to an attribute, the value is JSON parsed / stringified as necessary.
 
-          #### boolean
+          #### props.boolean / Boolean
 
           The \`boolean\` prop coerces all values to a boolean. Attributes, when true, are void. When false, they're removed.
 
-          #### number
+          #### props.number / Number
 
           The \`number\` prop coerces all values to be a number.
 
-          #### object
+          #### props.object / Object
 
           The \`object\` prop ensures that a default, empty object is available. It doesn't coerce any values, like the \`array\` prop, but it does ensure that attribute values are JSON parsed / stringified.
 
-          #### string
+          #### props.string / String
 
           The \`string\` prop ensures that whatever value is passed is coerced to a string.
         `}"></x-marked>


### PR DESCRIPTION
* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [x] Updated docs and upgrade instructions, if necessary.

## Rationale

Currently is necessary to import props from skatejs package to define simple props types like string, number etc

Given the skatejs design based on mixins, most of the times, this is the only import from skatejs when defining a component class

By allowing to use native constructors like String, Number the props import could be avoided. It's also pretty intuitive and align with other libraries like [lit-element](https://github.com/Polymer/lit-element/)

With this change is possible to do

```
class Test extends MyComponent {
  static props = {
     str: String,
     obj: Object
  }
}
```

## Implementation

Used a Map instance to store the props definitions mapped to correspondent native constructor

## Open questions

Should props.any be mapped to null?
Should be added a function `registerPropType` to allow  sharing custom properties? 

## Other

To test if props.* match to constructors needed to access private field _propsNormalised in tests
In normaliseAttributeDefinition i created a identity function to be used when necessary instead of creating a anonymous function on the fly  

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

* [ ] Document