### PR TITLE
sk-marked: fix baseline indentation stripping

### DIFF
--- a/packages/sk-marked/src/__tests__/utils.spec.js
+++ b/packages/sk-marked/src/__tests__/utils.spec.js
@@ -1,61 +1,59 @@
 import { format } from '../utils';
 
-describe('format', () => {
-  test('text without indentation', () => {
-    const text = `(line without indentantation)
+test('format text without indentation', () => {
+  const text = `(line without indentantation)
 (line without indentantation)
 
 (line without indentantation)
 
 `;
-    const formatted = format(text);
-    expect(formatted).toBe(text);
-  });
+  const formatted = format(text);
+  expect(formatted).toBe(text);
+});
 
-  test('text with mixed indentation but no baseline indentation', () => {
-    const text = `  (line indented with 2 spaces)
+test('format text with mixed indentation but no baseline indentation', () => {
+  const text = `  (line indented with 2 spaces)
  (line indented with 1 space)
 \t\t(line indented with 2 tabs)
 
 (line without indentantation)
 
 `;
-    const formatted = format(text);
-    expect(formatted).toBe(text);
-  });
+  const formatted = format(text);
+  expect(formatted).toBe(text);
+});
 
-  test('text with baseline indentation of 2 spaces/tabs', () => {
-    const text = `  (line indented with 2 spaces)
+test('format text with baseline indentation of 2 spaces/tabs', () => {
+  const text = `  (line indented with 2 spaces)
   (line indented with 2 spaces)
     (line indented with 4 spaces)
 \t\t(line indented with 2 tabs)
   (line indented with 2 spaces)`;
 
-    const expectedText = `(line indented with 2 spaces)
+  const expectedText = `(line indented with 2 spaces)
 (line indented with 2 spaces)
   (line indented with 4 spaces)
 (line indented with 2 tabs)
 (line indented with 2 spaces)`;
 
-    const formatted = format(text);
-    expect(formatted).toBe(expectedText);
-  });
+  const formatted = format(text);
+  expect(formatted).toBe(expectedText);
+});
 
-  test('text without indentation with carriage return + line feed', () => {
-    const text = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
+test('format text without indentation with carriage return + line feed', () => {
+  const text = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
 
-    const expectedText = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
+  const expectedText = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
 
-    const formatted = format(text);
-    expect(formatted).toBe(expectedText);
-  });
+  const formatted = format(text);
+  expect(formatted).toBe(expectedText);
+});
 
-  test('text with indentation with carriage return + line feed', () => {
-    const text = `  (line indented with 2 spaces)\r\n (line indented with 1 space)\r\n\t\t(line indented with 2 tabs)`;
+test('format text with indentation with carriage return + line feed', () => {
+  const text = `  (line indented with 2 spaces)\r\n (line indented with 1 space)\r\n\t\t(line indented with 2 tabs)`;
 
-    const expectedText = ` (line indented with 2 spaces)\r\n(line indented with 1 space)\r\n\t(line indented with 2 tabs)`;
+  const expectedText = ` (line indented with 2 spaces)\r\n(line indented with 1 space)\r\n\t(line indented with 2 tabs)`;
 
-    const formatted = format(text);
-    expect(formatted).toBe(expectedText);
-  });
+  const formatted = format(text);
+  expect(formatted).toBe(expectedText);
 });

--- a/packages/sk-marked/src/__tests__/utils.spec.js
+++ b/packages/sk-marked/src/__tests__/utils.spec.js
@@ -1,0 +1,61 @@
+import { format } from '../utils';
+
+describe('format', () => {
+  test('text without indentation', () => {
+    const text = `(line without indentantation)
+(line without indentantation)
+
+(line without indentantation)
+
+`;
+    const formatted = format(text);
+    expect(formatted).toBe(text);
+  });
+
+  test('text with mixed indentation but no baseline indentation', () => {
+    const text = `  (line indented with 2 spaces)
+ (line indented with 1 space)
+\t\t(line indented with 2 tabs)
+
+(line without indentantation)
+
+`;
+    const formatted = format(text);
+    expect(formatted).toBe(text);
+  });
+
+  test('text with baseline indentation of 2 spaces/tabs', () => {
+    const text = `  (line indented with 2 spaces)
+  (line indented with 2 spaces)
+    (line indented with 4 spaces)
+\t\t(line indented with 2 tabs)
+  (line indented with 2 spaces)`;
+
+    const expectedText = `(line indented with 2 spaces)
+(line indented with 2 spaces)
+  (line indented with 4 spaces)
+(line indented with 2 tabs)
+(line indented with 2 spaces)`;
+
+    const formatted = format(text);
+    expect(formatted).toBe(expectedText);
+  });
+
+  test('text without indentation with carriage return + line feed', () => {
+    const text = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
+
+    const expectedText = `  (line indented with 2 spaces)\r\n(line not indented)\r\n\t\t(line indented with 2 tabs)`;
+
+    const formatted = format(text);
+    expect(formatted).toBe(expectedText);
+  });
+
+  test('text with indentation with carriage return + line feed', () => {
+    const text = `  (line indented with 2 spaces)\r\n (line indented with 1 space)\r\n\t\t(line indented with 2 tabs)`;
+
+    const expectedText = ` (line indented with 2 spaces)\r\n(line indented with 1 space)\r\n\t(line indented with 2 tabs)`;
+
+    const formatted = format(text);
+    expect(formatted).toBe(expectedText);
+  });
+});

--- a/packages/sk-marked/src/index.js
+++ b/packages/sk-marked/src/index.js
@@ -1,37 +1,20 @@
 import { define, props, withComponent } from 'skatejs';
 import marked from 'marked';
+import { format } from './utils';
 
-function format(src) {
-  src = src.replace(/"/g, '&quot;');
-
-  // Remove leading newlines.
-  src = src.split('\n');
-
-  // Get the initial indent so we can remove it from subsequent lines.
-  const indent = src[1] ? src[1].match(/^\s*/)[0].length : 0;
-
-  // Format indentation.
-  src = src.map(s => s.substring(indent));
-
-  // Re-instate newline formatting.
-  return src.join('\n');
-}
-
-export default define(
-  class extends withComponent() {
-    static is = 'sk-marked';
-    static props = {
-      css: props.string,
-      renderers: props.object,
-      src: props.string
-    };
-    render({ css, renderers, src }) {
-      const renderer = new marked.Renderer();
-      Object.assign(renderer, renderers);
-      return `
+export default define(class extends withComponent() {
+  static is = 'sk-marked';
+  static props = {
+    css: props.string,
+    renderers: props.object,
+    src: props.string
+  };
+  render({ css, renderers, src }) {
+    const renderer = new marked.Renderer();
+    Object.assign(renderer, renderers);
+    return `
       <style>${css}></style>
       ${marked(format(src), { renderer })}
     `;
-    }
   }
-);
+});

--- a/packages/sk-marked/src/utils.js
+++ b/packages/sk-marked/src/utils.js
@@ -1,0 +1,29 @@
+export function format(src) {
+  src = src.replace(/"/g, '&quot;');
+
+  // Remove leading newlines.
+  let lines = src.split('\n');
+
+  // Get baseline indentation so we can remove it from all lines.
+  let lineIndent;
+  let baseIndent;
+  for (let i = 0; i < lines.length; i++) {
+    lineIndent = lines[i].match(/^\s+/);
+    if (!lineIndent) {
+      baseIndent = 0;
+      break;
+    }
+    baseIndent = Math.min(
+      baseIndent || lineIndent[0].length,
+      lineIndent[0].length
+    );
+  }
+
+  // Format indentation if necessary
+  if (baseIndent) {
+    lines = lines.map(s => s.substring(baseIndent));
+  }
+
+  // Re-instate newline formatting.
+  return lines.join('\n');
+}


### PR DESCRIPTION
Fixes #1457 

* [X] Bug 
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Previous implementation was stripping more than necessary

## Implementation

Its straight forward: check indentation of each line to detect baseline indentation. If no indentation is found break loop and dont strip lines