### PR TITLE
context implementation that doesn't rely on the DOM tree

### DIFF
--- a/packages/skatejs/src/createContext.js
+++ b/packages/skatejs/src/createContext.js
@@ -1,0 +1,88 @@
+// @flow
+
+class Group extends Map {
+  set(...itemsInGroup) {
+  }
+}
+
+export function createContext(props: any): Context {
+
+  class Context {
+
+    constructor() {
+      this._callbacks = new Map
+      this._updatedProps = new Set
+    }
+
+    observe(props, callback) {
+      for (const prop of props) {
+        let callbacksForProp = this._callbacks.get(prop)
+
+        if (!callbacksForProp)
+          this._callbacks.set(prop, callbacksForProp = new Set)
+
+        callbacksForProp.add(callback)
+      }
+    }
+
+    unobserve(callback) {
+      for (const prop of props) {
+        const callbacksForProp = this._callbacks.get(prop)
+
+        if (callbacksForProp)
+          callbacksForProp.delete(callback)
+      }
+    }
+
+    _scheduleCallbacksForProp(prop) {
+      this._updatedProps.add(prop)
+
+      if (this._callbacksScheduled) return
+      this._callbacksScheduled = true
+
+      Promise.resolve().then(() => {
+        this._callbacksScheduled = false
+        this._runCallbacks()
+      })
+    }
+
+    _runCallbacks() {
+      const callbacksToCall = new Set
+
+      for (const prop of this._updatedProps) {
+        const callbacksForProp = this._callbacks.get(prop)
+
+        if (callbacksForProp) {
+          for (const callback of callbacksForProp) {
+            callbacksToCall.add(callback)
+          }
+        }
+      }
+
+      this._updatedProps.clear()
+
+      for (const callback of callbacksToCall) {
+        callback()
+      }
+    }
+
+  }
+
+  const propValues = {}
+
+  const context = new Context
+
+  for (let prop of props) {
+    Object.defineProperty(context, prop, {
+      get: () => propValues[prop],
+      set: value => {
+        propValues[prop] = value
+        this._updatedProps.add(prop)
+        this._scheduleCallbacksForProp(prop)
+      }
+    })
+  }
+
+  return Object.freeze(context)
+
+}

--- a/packages/skatejs/src/with-context.js
+++ b/packages/skatejs/src/with-context.js
@@ -2,19 +2,26 @@
 
 export const withContext = (Base: Class<any> = HTMLElement): Class<any> =>
   class extends Base {
-    get context(): Object {
-      if (this._context) {
-        return this._context;
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback()
+
+      this._contextCallbacks = new Set
+
+      for (const contextDescriptor in this.constructor.contexts) {
+        const context = contextDescriptor[0]
+        const observedProps = contextDescriptor.slice(1)
+        const callback = () => this.triggerUpdate()
+        this._contextCallbacks.add(callback)
+        context.observe(observedProps, callback)
       }
-      let node = this;
-      while ((node = node.parentNode || node.host)) {
-        if ('context' in node) {
-          return node.context;
-        }
-      }
-      return {};
     }
-    set context(context: Object): void {
-      this._context = context;
+
+    disconnectedCallback() {
+      super.disconnectedCallback && super.disconnectedCallback()
+
+      for (const callback of this._contextCallbacks)
+        context.unobserve(callback)
+
+      this._contextCallbacks = null
     }
-  };
+  }


### PR DESCRIPTION
This is an initial implementation of the idea in #1453. It's not tested yet, but paints the picture.

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

See https://github.com/skatejs/skatejs/issues/1453

## Implementation

This way it doesn't rely on the DOM tree structure, and there's no overriding of contexts by other contexts (as there would be in the named-context and inheriting-context ideas also mentioned in #1453).


## Tasks

* [ ] docs
* [ ] tests
