### PR TITLE
a DOM node can contain contexts, and subnodes can get them by unique reference

### DIFF
--- a/packages/skatejs/src/createContext.js
+++ b/packages/skatejs/src/createContext.js
@@ -1,17 +1,19 @@
 // @flow
 
-class Group extends Map {
-  set(...itemsInGroup) {
-  }
-}
-
-export function createContext(initialProps: any): Context {
+export function defineContext(initialProps: any): Context {
+  initialProps = { ...initialProps }
 
   class Context {
 
     constructor() {
       this._callbacks = new Map
       this._updatedProps = new Set
+
+      this._propValues = {}
+
+      for (let prop in initialProps) {
+        this._propValues[prop] = initialProps[prop]
+      }
     }
 
     observe(props, callback) {
@@ -66,23 +68,17 @@ export function createContext(initialProps: any): Context {
 
   }
 
-  const propValues = {}
-
-  const context = new Context
-
   for (let prop in initialProps) {
-    propValues[prop] = initialProps[prop]
-
-    Object.defineProperty(context, prop, {
-      get: () => propValues[prop],
-      set: value => {
-        propValues[prop] = value
+    Object.defineProperty(Context.prototype, prop, {
+      get() { return this._propValues[prop] },
+      set(value) {
+        this._propValues[prop] = value
         this._updatedProps.add(prop)
         this._scheduleCallbacksForProp(prop)
       }
     })
   }
 
-  return Object.freeze(context)
+  return Context
 
 }

--- a/packages/skatejs/src/with-context.js
+++ b/packages/skatejs/src/with-context.js
@@ -1,27 +1,86 @@
 // @flow
 
-export const withContext = (Base: Class<any> = HTMLElement): Class<any> =>
-  class extends Base {
+class ContextGetter {
+
+  constructor(el) {
+    this.el = el
+    this._cache = new Map
+  }
+
+  get(Context) {
+    if (!this.el.constructor.consumes.find(ctx => ctx[0] === Context))
+      throw new Error('Not subscribed to specified context')
+
+    if (this._cache.has(Context)) return this._cache.get(Context)
+
+    let node = this.el
+
+    while ((node = node.parentNode || node.host)) {
+      if (node.constructor.provides && node.constructor.provides.includes(Context)) {
+        let context = node._providedContexts.get(Context)
+
+        if (!context) {
+          context = new Context
+          node._providedContexts.set(Context, context)
+        }
+
+        this._cache.set(Context, context)
+
+        return context
+      }
+    }
+
+    throw new Error('Context not found')
+  }
+
+  clear() {
+    this._cache.clear()
+  }
+
+}
+
+export const withContext = (Base: Class<any> = HTMLElement): Class<any> => {
+  return class extends Base {
+    constructor(...args) {
+      super(...args)
+
+      if (this.constructor.provides) {
+        this._providedContexts = new Map
+        for (const Context of this.constructor.provides) {
+          if (!this._providedContexts.has(Context))
+            this._providedContexts.set(Context, new Context)
+        }
+      }
+    }
+
     connectedCallback() {
       super.connectedCallback && super.connectedCallback()
 
-      this._contextCallbacks = new Set
+      if (this.constructor.consumes) {
+        this.contexts = new ContextGetter
+        this._contextCallbacks = new Map
 
-      for (const contextDescriptor in this.constructor.contexts) {
-        const context = contextDescriptor[0]
-        const observedProps = contextDescriptor.slice(1)
-        const callback = () => this.triggerUpdate()
-        this._contextCallbacks.add(callback)
-        context.observe(observedProps, callback)
+        for (const contextDescriptor of this.constructor.consumes) {
+          const Context = contextDescriptor[0]
+          const context = this.contexts.get(Context)
+          const observedProps = contextDescriptor.slice(1)
+          const callback = () => this.triggerUpdate()
+          this._contextCallbacks.set(context, callback)
+          context.observe(observedProps, callback)
+        }
       }
     }
 
     disconnectedCallback() {
       super.disconnectedCallback && super.disconnectedCallback()
 
-      for (const callback of this._contextCallbacks)
-        context.unobserve(callback)
+      if (this.constructor.consumes) {
+        for (const [context, callback] of this._contextCallbacks)
+          context.unobserve(callback)
 
-      this._contextCallbacks = null
+        this._contextCallbacks = null
+        this.contexts.clear()
+      }
     }
   }
+}


### PR DESCRIPTION
This is an initial implementation of the idea in #1453. It's not tested yet. Some parts might be incomplete, but it shows the idea.

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

See https://github.com/skatejs/skatejs/issues/1453

## Implementation

This is similar to the original idea of contexts being relative to a parent element, but without them being overridden by intermediary contexts.

## Basic usage

Working demo: https://codepen.io/trusktr/project/editor/XbEOMk

```html
<el-with-context>
  <el-that-consumes>
  </el-that-consumes>
</el-with-context>
```

```js
// ./ElWithContext.js
import {withComponent} from 'skatejs'
import {SomeContext} from './SomeContext'

class ElWithContext extends withComponent() {
  static get provides() { return [ SomeContext ] }
  // ...
}

customElements.define('el-with-context', ElWithContext)
```

```js
// ./ElThatConsumes.js
import {withComponent} from 'skatejs'
import {SomeContext} from './SomeContext'

class ElThatConsumes extends withComponent() {
  static get consumes() { return [
    [ SomeContext, 'count' ] // subscribe to the `count` prop of `SomeContext`
  ] }

  connectedCallback() {
    super.connectedCallback()
    this.contexts.get(SomeContext).startCounter()
  }

  render() {
    const {count} = this.contexts.get(SomeContext)
    return <div>The count is: {count}</div>
  }
}

customElements.define('el-that-consumes', ElThatConsumes)
```

```js
// ./SomeContext.js
import {defineContext} from 'skatejs'

export const SomeContext = defineContext({
  count: 0

  startCounter() {
    setInterval(() => {
      someContext.count++
    }, 1000)
  },
})
```


## Tasks

* [ ] docs
* [ ] tests
