### PR TITLE
snabbdom: do not override props to return children (a slot vnode)

### DIFF
--- a/packages/renderer-snabbdom/src/index.js
+++ b/packages/renderer-snabbdom/src/index.js
@@ -5,14 +5,6 @@ export default function createMixin(modules) {
   var patch = init(modules);
   return (Base = HTMLElement) =>
     class extends Base {
-      get props() {
-        // We override props so that we can satisfy most use
-        // cases for children by using a slot.
-        return {
-          ...super.props,
-          ...{ children: vnode('slot', {}, [], undefined, undefined) }
-        };
-      }
       renderer(root, call) {
         this._renderRoot = root;
         let newVTree = call();


### PR DESCRIPTION
 #1466

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

The props override does not works with withChildren mixin which is part of withComponent #1466 . 

Since any component built with snabbdom renderer is broken it cannot considered a breaking change. Also this renderer is still not documented

The consistency between renderers also is not broke because lit-html renderer already do not return children