### PR TITLE
Remove custom Symbol implementation

### DIFF
--- a/packages/skatejs/src/util.js
+++ b/packages/skatejs/src/util.js
@@ -19,11 +19,3 @@ export function keys(obj: Object | void): Array<any> {
     ? names.concat(Object.getOwnPropertySymbols(obj))
     : names;
 }
-
-let symbolCount = 0;
-export function sym(description?: string): Symbol | string {
-  description = String(description || ++symbolCount);
-  return typeof Symbol === 'function'
-    ? Symbol(description)
-    : `__skate_${description}`;
-}

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -6,7 +6,7 @@ import type {
   PropTypes,
   PropTypesNormalized
 } from './types.js';
-import { dashCase, empty, keys, sym } from './util.js';
+import { dashCase, empty, keys } from './util.js';
 
 export function normalizeAttributeDefinition(
   name: string | Symbol,

--- a/packages/skatejs/test/unit/util.spec.js
+++ b/packages/skatejs/test/unit/util.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { dashCase, debounce, keys, sym } from '../../src/util';
+import { dashCase, debounce, keys } from '../../src/util';
 
 describe('utils', () => {
   describe('{ dashCase }', () => {
@@ -42,21 +42,10 @@ describe('utils', () => {
     });
 
     it('should return both normal keys and symbol keys from an object', () => {
-      const _sym = sym('_sym');
+      const _sym = Symbol('_sym');
       const names = keys({ foo: 1, [_sym]: 2 });
       expect(names[0]).toBe('foo');
       expect(names[1]).toBe(_sym);
-    });
-  });
-
-  describe('{ sym }', () => {
-    it('should return a new symbol when supported', () => {
-      const _sym = sym('test');
-      if (typeof Symbol === 'function') {
-        expect(typeof _sym).toBe('symbol');
-      } else {
-        expect(typeof _sym).toBe('string');
-      }
     });
   });
 });

--- a/packages/skatejs/test/unit/with-update.spec.js
+++ b/packages/skatejs/test/unit/with-update.spec.js
@@ -3,7 +3,6 @@
 import { mount } from '@skatejs/bore';
 import { h as preactH } from 'preact';
 import { define, name, prop, props, withUpdate } from '../../src';
-import { sym } from '../../src/util';
 
 import afterMutations from '../lib/after-mutations';
 import fixture from '../lib/fixture';
@@ -383,8 +382,8 @@ describe('withUpdate', () => {
     }
 
     let elem;
-    const secret1 = sym('secret1');
-    const secret2 = sym('secret2');
+    const secret1 = Symbol('secret1');
+    const secret2 = Symbol('secret2');
 
     beforeEach(done => {
       elem = new (define(class extends withUpdate() {


### PR DESCRIPTION
* [x] Cleanup

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

The custom Symbol implementation (sym function) is not being used anywhere in library code. It was used only in tests where it always using native implementation

## Implementation

Just remove it