### PR TITLE
fix: inherit `observedAttributes`, if they exist in the base class.

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -159,7 +159,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.
       defineProps(this);
-      return this._observedAttributes;
+      return this._observedAttributes.concat(super.observedAttributes || []);
     }
 
     static get props(): PropTypesNormalized {

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -159,7 +159,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.
       defineProps(this);
-      return this._observedAttributes.concat(super.observedAttributes || []);
+      return [...(super.observedAttributes || []), this._observedAttributes];
     }
 
     static get props(): PropTypesNormalized {

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -159,7 +159,9 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.
       defineProps(this);
-      return [...(super.observedAttributes || []), this._observedAttributes];
+      return Array.from(
+        new Set([...(super.observedAttributes || []), this._observedAttributes])
+      );
     }
 
     static get props(): PropTypesNormalized {


### PR DESCRIPTION


* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

I ran into an issue when using `withUpdate` on my own class hierarchies: `withUpdate` was not inheriting `observedAttributes` from a base class if the base class had them. This caused some things not to work.

## Implementation

This inherits the `observedAttributes` so that other non-Skate behavior will still register with the Custom Element API and things will still work.

## Tasks

* [ ] write a test.
