### PR TITLE
Simplify Snabbdom renderer

### DIFF
--- a/packages/renderer-snabbdom/src/index.js
+++ b/packages/renderer-snabbdom/src/index.js
@@ -12,7 +12,9 @@ export default function createMixin(modules) {
         let newVTree = call();
 
         if (!this._lastVTree) {
-          root.innerHTML = '<div style="display: contents"></div>';
+          const container = document.createElement('div');
+          container.style = 'display: contents';
+          root.appendChild(container);
           this._lastVTree = patch(root.children[0], newVTree);
         } else {
           this._lastVTree = patch(this._lastVTree, newVTree);

--- a/packages/renderer-snabbdom/src/index.js
+++ b/packages/renderer-snabbdom/src/index.js
@@ -6,25 +6,22 @@ export default function createMixin(modules) {
   return (Base = HTMLElement) =>
     class extends Base {
       _lastVTree = null;
-        
+
       renderer(root, call) {
         this._renderRoot = root;
         let newVTree = call();
 
-        // first render
         if (!this._lastVTree) {
-          this._lastVTree = patch(root, newVTree);
-        }
-
-        // all subsequent renders
-        else {
-          this._lastVTree = patch(this._lastVTree, newVTree)
+          root.innerHTML = '<div style="display: contents"></div>';
+          this._lastVTree = patch(root.children[0], newVTree);
+        } else {
+          this._lastVTree = patch(this._lastVTree, newVTree);
         }
       }
-      
+
       disconnectedCallback() {
         super.disconnectedCallback && super.disconnectedCallback();
-        patch(this._lastVTree, null)
+        patch(this._lastVTree, null);
       }
     };
 }

--- a/packages/renderer-snabbdom/src/index.js
+++ b/packages/renderer-snabbdom/src/index.js
@@ -13,11 +13,7 @@ export default function createMixin(modules) {
 
         // first render
         if (!this._lastVTree) {
-          const tmp = document.createElement('tmp');
-          this.root.appendChild(tmp);
-          
-          // replaces the `tmp` element with content described by the vnode
-          this._lastVTree = patch(tmp, newVTree);
+          this._lastVTree = patch(root, newVTree);
         }
 
         // all subsequent renders

--- a/packages/renderer-snabbdom/src/index.js
+++ b/packages/renderer-snabbdom/src/index.js
@@ -28,10 +28,7 @@ export default function createMixin(modules) {
       
       disconnectedCallback() {
         super.disconnectedCallback && super.disconnectedCallback();
-
-        // How to "unmount" the component?
-        // Waiting for a reply at https://github.com/snabbdom/snabbdom/issues/386
-        
+        patch(this._lastVTree, null)
       }
     };
 }


### PR DESCRIPTION

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Makes Snabbdom simpler, based on discussion at https://github.com/skatejs/skatejs/pull/1471.

## Implementation

It's the way the Snabbdom README prescribes rendering to DOM.

`disconnectedCallback` is missing the part to remove it from the DOM (waiting for a reply at https://github.com/snabbdom/snabbdom/issues/386).

But maybe, we don't need to worry about removing the DOM. If the SkateJS custom element is itself removed from the DOM, I think everything will be garbage collected because all Snabbdom VNode information is stored on the nodes themselves.

## Open questions

Should we unmount the rendered Snabbdom output?
