### PR TITLE
allow a getter for the default value

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -37,14 +37,16 @@ export function normalizePropertyDefinition(
   name: string,
   prop: PropType
 ): Object {
-  const { coerce, default: def, deserialize, serialize } = prop;
-  return {
+  const { coerce, deserialize, serialize } = prop;
+  const defaultDescriptor = Object.getOwnPropertyDescriptor(prop, 'default');
+  const result = {
     attribute: normalizeAttributeDefinition(name, prop),
     coerce: coerce || identity,
-    default: def,
     deserialize: deserialize || identity,
     serialize: serialize || identity
   };
+  Object.defineProperty(result, 'default', defaultDescriptor);
+  return result;
 }
 
 const defaultTypesMap = new Map();


### PR DESCRIPTION
* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Makes it easy to do define a getter for the default value, for example to generate random defaults like in this custom prop definition:

```js
import { Color } from 'three'
import { props } from 'skatejs'

Object.assign(props, {
    THREE: {
        Color: {
            attribute: { source: true }, // get the value from an attribute (but don't mirror it back)
            coerce: val => new Color( val ), // Color accepts integers or {r: _, g: _, b _} objects
 /*HERE->*/ get default() { return new Color( Math.random(), Math.random(), Math.random() ) }, // random default color
            deserialize: val => new Color( val ), // Color accepts CSS strings
            serialize: val => new Color( val ).getStyle(), // returns CSS string like "rbg(220, 130, 50)"
        },
    },
}

export { props }
```

Now every time I make a new instance, it has a random new default color if I didn't specify one via attribute. 👍 😄 

## Implementation

Currently, the default getter is read only once, during prop normalization. This allows it to always work after normalization, which is super useful for default value that should be dynamically generated.

## Open questions

_Are there any open questions about this implementation that need answers?_

## Tasks

* [ ] tests
* [ ] docs