### PR TITLE
Use lit-html over the deprecated lit-html-extended

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "highlight.js": "9.12.0",
     "jest-environment-node": "22.4.1",
     "js-beautify": "1.7.5",
-    "lit-html": "0.9.0",
+    "lit-html": "^0.11.0-dev.1",
     "marked": "0.3.14",
     "mkdirp": "0.5.1",
     "outdent": "^0.5.0",

--- a/packages/renderer-lit-html/package.json
+++ b/packages/renderer-lit-html/package.json
@@ -3,7 +3,7 @@
   "browser": "dist/es/index.js",
   "description": "A SkateJS renderer for Lit HTML.",
   "devDependencies": {
-    "lit-html": "0.9.0"
+    "lit-html": "^0.11.0-dev.1"
   },
   "esnext": "dist/esnext/index.js",
   "files": [
@@ -25,7 +25,7 @@
   "module": "dist/es/index.js",
   "name": "@skatejs/renderer-lit-html",
   "peerDependencies": {
-    "lit-html": "^0.9.0"
+    "lit-html": "^0.11.0-dev.1"
   },
   "version": "0.2.1"
 }

--- a/packages/renderer-lit-html/src/index.js
+++ b/packages/renderer-lit-html/src/index.js
@@ -1,4 +1,4 @@
-import { render } from 'lit-html/lib/lit-extended';
+import { render } from 'lit-html';
 
 export default (Base = HTMLElement) =>
   class extends Base {

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "@skatejs/sk-marked": "0.0.1",
     "@skatejs/sk-router": "0.2.0",
     "highlight.js": "9.12.0",
-    "lit-html": "0.9.0",
+    "lit-html": "^0.11.0-dev.1",
     "preact": "8.2.7",
     "prismjs": "1.12.2",
     "react": "15.6.2",

--- a/site/pages/renderers/with-lit-html.js
+++ b/site/pages/renderers/with-lit-html.js
@@ -25,15 +25,7 @@ export default class extends Component {
             LitHTML renderer
           </a>
           allows you to render using
-          <a href="https://github.com/PolymerLabs/lit-html">LitHTML</a>.
-        </p>
-
-        <p>
-          Please note this renderer uses Lit HTML's extended renderer by default. This provides slightly different
-          than default, and enhanced, functionality as described
-          <a href="https://github.com/PolymerLabs/lit-html/blob/master/src/lib/lit-extended.ts#L25">
-            here
-          </a>.
+          <a href="https://polymer.github.io/lit-html/">LitHTML</a>.
         </p>
         <x-runnable
           code="${codeWithLitHtml}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,9 +5673,9 @@ listr@^0.13.0:
     stream-to-observable "^0.2.0"
     strip-ansi "^3.0.1"
 
-lit-html@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.9.0.tgz#a445ecbb3da7d8b17690e6ade6c872c89385092a"
+lit-html@^0.11.0-dev.1:
+  version "0.11.0-dev.1"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.11.0-dev.1.tgz#15d2bb925540e2144bb399f7c6515d0bba9dd5c3"
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
* [ ] Bug
* [x] Feature?

## Requirements

* [x] Read the [contribution guidelines]
* [ ] Wrote tests.
* [x] Updated docs 
* [ ] upgrade instructions: Unclear where I can find these

## Rationale

[lit-extended is deprecated](https://github.com/Polymer/lit-html/blob/master/src/lib/lit-extended.ts#L57) and does no longer support all the features it did before (e.g., on-click binding).

## Implementation

Replaced the render call from lit-extended with the call to the default render function. 

## Open questions

- This is a breaking change. The semver of the renderer-lit-HTML version needs to be bumped to a new major version. Should we change the version to a beta version as long as the lit-HTML dependency points to a dev version?

## Other

This is a breaking change. All lit-HTML component needs to be updated to use the new syntax.

## Tasks

* [ ] Upgrade guide
* [ ] Bump version
