### PR TITLE
Fix the contribution guidelines link in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ _If there is a linked issue, mention it here._
 
 ## Requirements
 
-* [ ] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
+* [ ] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
 * [ ] Wrote tests.
 * [ ] Updated docs and upgrade instructions, if necessary.
 


### PR DESCRIPTION
* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [] Wrote tests.
* [] Updated docs and upgrade instructions, if necessary.

## Rationale

The link to the contribution guidelines in the PR template is broken.

## Implementation


## Open questions


## Other


## Tasks

