### PR TITLE
Fix extending builtin classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
           "flow",
           "react",
           "stage-0"
+        ],
+        "plugins": [
+          ["babel-plugin-transform-builtin-classes", {
+            "globals": ["HTMLElement", "Base"],
+            "logIfPatched": true
+          }]
         ]
       },
       "esnext": {
@@ -104,6 +110,7 @@
     "babel-plugin-dynamic-import-node": "1.2.0",
     "babel-plugin-modules-map": "1.0.0",
     "babel-plugin-modules-web-compat": "1.1.1",
+    "babel-plugin-transform-builtin-classes": "^0.6.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-skate-flow-props": "0.1.0",
     "babel-preset-env": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,14 @@ babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-builtin-classes@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-builtin-classes/-/babel-plugin-transform-builtin-classes-0.6.1.tgz#09286f575267f01d09d279a7d8e02d58739f16c2"
+  dependencies:
+    babel-plugin-transform-es2015-classes "^6.24.1"
+    babel-runtime "^6.23.0"
+    babel-template "^6.25.0"
+
 babel-plugin-transform-class-constructor-call@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz#80dc285505ac067dcb8d6c65e2f6f11ab7765ef9"
@@ -1372,14 +1380,14 @@ babel-register@6.26.0, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.25.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.25.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:


### PR DESCRIPTION
Use the babel-plugin-transform-builtin-classes in the es build to properly call the super constructor when extending HTMLElement.

Fixes #1465 

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

See #1465

## Implementation

Uses the [babel-plugin-transform-builtin-classes](https://github.com/WebReflection/babel-plugin-transform-builtin-classes/) to transform extends of built-in classes. The plugin only performs a static analysis to match base class names that might require the fix. Since skatejs use dynamic base classes it was needed to match the identifier `Base` that can potentially refer to a built-in class. 

I preferred the compilation step over using a library for inheritance since this is only needed when older browsers without class support are targeted. 

## Open questions

_Are there any open questions about this implementation that need answers?_


## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._
