### PR TITLE
simplify the props instance getter

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -171,13 +171,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     }
 
     get props(): Object {
-      return keys(this.constructor.props).reduce(
-        (prev: Object, curr: string) => {
-          prev[curr] = (this: any)[curr];
-          return prev;
-        },
-        {}
-      );
+      return { ...this._props };
     }
 
     set props(props: Object) {


### PR DESCRIPTION


* [ ] Bug
* [ ] Feature
* [x] refactor

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Seems like that does the same thing.

## Implementation

_Why have you implemented it this way?_

To make it simpler

## Open questions

Do we need to use `keys()` for a specific reason?