### PR TITLE
the default property of a prop definition is a function, so we can do…

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -41,7 +41,7 @@ export function normalizePropertyDefinition(
   return {
     attribute: normalizeAttributeDefinition(name, prop),
     coerce: coerce || identity,
-    default: def,
+    default: typeof def === 'function' ? def : () => def,
     deserialize: deserialize || identity,
     serialize: serialize || identity
   };
@@ -97,7 +97,7 @@ export function prop(definition: PropType | void): Function {
       configurable: true,
       get() {
         const val = this._props[name];
-        return val == null ? normalized.default : val;
+        return val == null ? normalized.default.call(this) : val;
       },
       set(val) {
         const { attribute: { target }, serialize } = normalized;
@@ -216,7 +216,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
           const { default: defaultValue, deserialize } = propertyDefinition;
           const propertyValue = deserialize ? deserialize(newValue) : newValue;
           this._props[propertyName] =
-            propertyValue == null ? defaultValue : propertyValue;
+            propertyValue == null ? defaultValue.call(this) : propertyValue;
           this.triggerUpdate();
         }
       }


### PR DESCRIPTION
The default property of a prop definition can be a function, so we can do useful things like call `Math.random` or use `this` to do instance-specific things.

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

This makes it easy to make dynamic default values. For example,

```js
const THREEColorProp = {
    attribute: { source: true, target: false }, // get the value from an attribute (but don't mirror it back)
    coerce: val => val instanceof Color ? val : new Color(val),
    deserialize: val => new Color(val), // f.e. accepts a hex "#af3eea" color string
    serialize: val => new Color( val ).getStyle(), // returns a CSS "rbg()" string

    // Let the default Color be random for each instance that has this prop
    default: () => new Color( Math.random(), Math.random(), Math.random() ), // R, G, B
}
```

## Implementation

This way the value can be a default static value, or a function that returns a value. If a function, it is called every time a default value is needed, and also called with `this` which can be useful in some cases where props are designed to work with certain classes that handle their own default values. 

Basically, it gives the end user more flexibility.

The only caveat (which we'd put in the docs) is that if the value is meant to be a function, then the function should be returned from the function:

```js
const someFunction = () => { /* ... */ }

class Foo extends withUpdate(HTMLElement) {
    static props = {
        foo: {
            // ...
            default: () => someFunction
        }
    }
}
```

## Tasks


* [ ] add to docs
* [ ] add a test
