### PR TITLE
Access `this` and property names in prop functions

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -97,7 +97,9 @@ export function prop(definition: PropType | void): Function {
       configurable: true,
       get() {
         const val = this._props[name];
-        return val == null ? normalized.default.call(this, name) : val;
+        return val == null
+          ? (this._props[name] = normalized.default.call(this, name))
+          : val;
       },
       set(val) {
         const { attribute: { target }, serialize, coerce } = normalized;

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -97,19 +97,21 @@ export function prop(definition: PropType | void): Function {
       configurable: true,
       get() {
         const val = this._props[name];
-        return val == null ? normalized.default.call(this) : val;
+        return val == null ? normalized.default.call(this, name) : val;
       },
       set(val) {
-        const { attribute: { target }, serialize } = normalized;
+        const { attribute: { target }, serialize, coerce } = normalized;
         if (target) {
-          const serializedVal = serialize ? serialize(val) : val;
+          const serializedVal = serialize
+            ? serialize.call(this, val, name)
+            : val;
           if (serializedVal == null) {
             this.removeAttribute(target);
           } else {
             this.setAttribute(target, serializedVal);
           }
         }
-        this._props[name] = normalized.coerce(val);
+        this._props[name] = coerce.call(this, val, name);
         this.triggerUpdate();
       }
     });
@@ -214,7 +216,9 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
         const propertyDefinition = _propsNormalized[propertyName];
         if (propertyDefinition) {
           const { default: defaultValue, deserialize } = propertyDefinition;
-          const propertyValue = deserialize ? deserialize(newValue) : newValue;
+          const propertyValue = deserialize
+            ? deserialize.call(this, newValue, propertyName)
+            : newValue;
           this._props[propertyName] =
             propertyValue == null ? defaultValue.call(this) : propertyValue;
           this.triggerUpdate();


### PR DESCRIPTION
This expands on PR https://github.com/skatejs/skatejs/pull/1507. Related issue: https://github.com/skatejs/skatejs/issues/1493

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

This makes the API more flexible for certain use cases while maintaining backwards compatibility (except for the case where a `default` value should be a function, see the other pull request).

This is awesome because it let's me greatly simplify my classes. It let's me handle values in special way so I can avoid creating new objects and gain performance improvements as well as code structuring improvements so that I can work with existing functionality rather than having to re-write classes. 

Existing functionality in my classes keeps the same objects around for each property, and this new `withUpdate` functionality allows me to keep this. Otherwise I'd have to re-write my classes so that they work with more diffing and always new object references every time a prop is set (especially not desirable for games/graphics/animations, which is what I'm making).

I'm using it like follows (note I'm using it in both the current way and the new way, to show it is backwards compatible):

```js
import { props as skateProps } from 'skatejs'
import { Color } from 'three'
import XYZValues from '../../core/XYZValues'
import XYZNumberValues from '../../core/XYZNumberValues'
import XYZNonNegativeValues from '../../core/XYZNonNegativeValues'
import XYZStringValues from '../../core/XYZStringValues'
import XYZSizeModeValues from '../../core/XYZSizeModeValues'

// creates a prop definition using the existing `withUpdate` functionality.
function createGenericPropType(Type, override = {}) {
    return {
        attribute: { source: true, target: false }, // get the value from an attribute (but don't mirror it back)
        coerce: val => val instanceof Type ? val : new Type(val),
        default: new Type,
        deserialize: val => new Type(val),
        serialize: val => val.toString(),
        ...override,
    }
}

// creates a prop definition for use with certain of my classes, taking advantage of these new features
// so that we can cache/serialize/deserialize to/from existing objects without creating new ones.
// This open up other possibilities too...
function createXYZPropType(Type, override = {}) {
    return {
        attribute: { source: true, target: false }, // get the value from an attribute (but don't mirror it back)
        coerce(val, propName) { return val === this.element[propName] ? val : this.element[propName].from(val) },
        default(propName) { return this.element[propName] },
        deserialize(val, propName) { return this.element[propName].fromString(val) },
        serialize(val, propName) { this.element[propName].toString() },
        ...override,
    }
}

const props = Object.assign({}, skateProps, {
    THREE: {
        Color: createGenericPropType(Color, {
            default: () => new Color( Math.random(), Math.random(), Math.random() ),
            serialize: val => new Color( val ).getStyle(), // returns a CSS "rbg()" string
        }),
    },
    XYZValues: createXYZPropType(XYZValues),
    XYZNumberValues: createXYZPropType(XYZNumberValues),
    XYZNonNegativeValues: createXYZPropType(XYZNonNegativeValues),
    XYZStringValues: createXYZPropType(XYZStringValues),
    XYZSizeModeValues: createXYZPropType(XYZSizeModeValues),
})

export { props }
```

## Implementation

This was the simplest way to implement it to allow extra flexibility with backwards compatibility (except for `function` default values, see https://github.com/skatejs/skatejs/pull/1507).

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

* [ ] docs
* [ ] test