### PR TITLE
Access this in props

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -41,7 +41,7 @@ export function normalizePropertyDefinition(
   return {
     attribute: normalizeAttributeDefinition(name, prop),
     coerce: coerce || identity,
-    default: def,
+    default: typeof def === 'function' ? def : () => def,
     deserialize: deserialize || identity,
     serialize: serialize || identity
   };
@@ -97,7 +97,7 @@ export function prop(definition: PropType | void): Function {
       configurable: true,
       get() {
         const val = this._props[name];
-        return val == null ? normalized.default : val;
+        return val == null ? normalized.default.call(this) : val;
       },
       set(val) {
         const { attribute: { target }, serialize } = normalized;
@@ -216,7 +216,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
           const { default: defaultValue, deserialize } = propertyDefinition;
           const propertyValue = deserialize ? deserialize(newValue) : newValue;
           this._props[propertyName] =
-            propertyValue == null ? defaultValue : propertyValue;
+            propertyValue == null ? defaultValue.call(this) : propertyValue;
           this.triggerUpdate();
         }
       }

--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -97,19 +97,21 @@ export function prop(definition: PropType | void): Function {
       configurable: true,
       get() {
         const val = this._props[name];
-        return val == null ? normalized.default.call(this) : val;
+        return val == null ? normalized.default.call(this, name) : val;
       },
       set(val) {
-        const { attribute: { target }, serialize } = normalized;
+        const { attribute: { target }, serialize, coerce } = normalized;
         if (target) {
-          const serializedVal = serialize ? serialize(val) : val;
+          const serializedVal = serialize
+            ? serialize.call(this, val, name)
+            : val;
           if (serializedVal == null) {
             this.removeAttribute(target);
           } else {
             this.setAttribute(target, serializedVal);
           }
         }
-        this._props[name] = normalized.coerce(val);
+        this._props[name] = coerce.call(this, val, name);
         this.triggerUpdate();
       }
     });
@@ -214,7 +216,9 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
         const propertyDefinition = _propsNormalized[propertyName];
         if (propertyDefinition) {
           const { default: defaultValue, deserialize } = propertyDefinition;
-          const propertyValue = deserialize ? deserialize(newValue) : newValue;
+          const propertyValue = deserialize
+            ? deserialize.call(this, newValue, propertyName)
+            : newValue;
           this._props[propertyName] =
             propertyValue == null ? defaultValue.call(this) : propertyValue;
           this.triggerUpdate();


### PR DESCRIPTION
Builds off of PR https://github.com/skatejs/skatejs/pull/1508. Related issue: https://github.com/skatejs/skatejs/issues/1493

* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

SkateJS already knows which props have changed, so we can drastically clean up end user code by simply exposing this information.


This drastically cleaned up some of my code. For example, I had code that I changed from

```js
    constructor(element) {
        Super(this).constructor(element)

        Private(this).lastSize = [null, null, null]
        Private(this).lastSizeMode = [null, null, null]
    },

    updated( oldProps, oldState ) {
        if (Private(this).sizeChanged(this.size, this.sizeMode)) {
            this._updateGeometryOnSizeChange(this.size)
        }
    },

    private: {
        lastSize: [null, null, null],
        lastSizeMode: [null, null, null],

        sizeChanged(newSize, newSizeMode) {
            let result = false

            if (
                this.lastSize[0] !== newSize.x ||
                this.lastSize[1] !== newSize.y ||
                this.lastSize[2] !== newSize.z
            ) {
                result = true
                this.lastSize[0] = newSize.x
                this.lastSize[1] = newSize.y
                this.lastSize[2] = newSize.z
            }

            if (
                this.lastSizeMode[0] !== newSizeMode.x ||
                this.lastSizeMode[1] !== newSizeMode.y ||
                this.lastSizeMode[2] !== newSizeMode.z
            ) {
                result = true
                this.lastSizeMode[0] = newSizeMode.x
                this.lastSizeMode[1] = newSizeMode.y
                this.lastSizeMode[2] = newSizeMode.z
            }

            return result
        },
    },
```

to

```js
    updated( oldProps, oldState, modifiedProps ) {
        if ( modifiedProps.has('size') || modifiedProps.has('sizeMode') ) {
            this._updateGeometryOnSizeChange(this.size)
        }
    },
```

This is highly valuable!

## Implementation

Implemented this way to be backwards compatible. Existing code continues to work as is.

## Tasks

_List any tasks you need to do here, if any. Delete this section if you don't need it._

* [ ] test
* [ ] docs
