### PR TITLE
Fix classList mutation methods

### DIFF
--- a/packages/ssr/register/ClassList.js
+++ b/packages/ssr/register/ClassList.js
@@ -1,6 +1,8 @@
 // TODO performance test and update this from class accessors instead.
 function set(list) {
-  return new Set((list._elem.className || '').split(' '));
+  const classList =
+    (list._elem.className && list._elem.className.split(' ')) || [];
+  return new Set(classList);
 }
 
 class ClassList {
@@ -8,14 +10,18 @@ class ClassList {
     this._elem = elem;
   }
   add(name) {
-    set(this).add(name);
+    const classList = set(this).add(name);
+    this._elem.className = Array.from(classList).join(' ');
     return this;
   }
   contains(name) {
     return set(this).has(name);
   }
   remove(name) {
-    set(this).delete(name);
+    const classList = set(this);
+    classList.delete(name);
+
+    this._elem.className = Array.from(classList).join(' ');
     return this;
   }
 }

--- a/packages/ssr/test/ClassList.test.js
+++ b/packages/ssr/test/ClassList.test.js
@@ -1,0 +1,18 @@
+describe('ClassList', () => {
+  it('add', () => {
+    const div = document.createElement('div');
+    div.classList.add('foo');
+    expect(div.className).toBe('foo');
+  });
+  it('remove', () => {
+    const div = document.createElement('div');
+    div.className = 'foo bar';
+    div.classList.remove('foo');
+    expect(div.className).toBe('bar');
+  });
+  it('contains', () => {
+    const div = document.createElement('div');
+    div.classList.add('foo');
+    expect(div.classList.contains('foo')).toBe(true);
+  });
+});


### PR DESCRIPTION
Skate SSR's implementation of classList does not make mutations to the className, this PR fixed the issues and adds tests.

_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/5.x/CONTRIBUTING.md).
* [x] Wrote tests.
* [x] Updated docs and upgrade instructions, if necessary.

## Rationale
Fixes #1512

## Implementation
I didn't try anything else. I didn't feel the need to try and micro-optimize this implementation for obvious reasons.

## Open questions
What's going on with the deploy preview? It failed with `failed during stage 'building site': Deploy directory 'site/public' does not exist`. My changes should not have caused this.

## Other
All these questions make contributing painful.