### PR TITLE
oldProps and oldState are initially null, which can be used to detect the initial update

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -130,8 +130,8 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _observedAttributes: Array<string>;
     static _props: Object;
 
-    _prevProps: Object;
-    _prevState: Object;
+    _prevProps: Object | null;
+    _prevState: Object | null;
     _props: Object;
     _state: Object;
     _syncingAttributeToProperty: null | string;
@@ -149,8 +149,8 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _observedAttributes = [];
     static _props = {};
 
-    _prevProps = {};
-    _prevState = {};
+    _prevProps = null;
+    _prevState = null;
     _props = {};
     _state = {};
 


### PR DESCRIPTION
Not sure this is a good change, but let me explain my intial reasoning.


* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

The thinking was that this could make it easy to detect the initial update:

```js
updated(oldProps) {
  if (!oldProps) {
    // this is the initial update
  }
  else {
    // continue as normal
  }
}
```

## Implementation

This was the simplest change to make

## Open questions

Is this worth it? Maybe I should just rely on `connectedCallback`?

However, note that `connectedCallback` does call `triggerUpdate` and thus ind

## Tasks


* [ ] test
* [ ] docs

I leave these as TODO unless we decide we want the change, so I don't spend time on it until needed.
