### PR TITLE
remove state? we already have all the functionality we need in props

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -131,18 +131,16 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _props: Object;
 
     _prevProps: Object;
-    _prevState: Object;
     _props: Object;
-    _state: Object;
     _syncingAttributeToProperty: null | string;
     _syncingPropertyToAttribute: boolean;
     _updating: boolean;
     _wasInitiallyRendered: boolean;
 
-    updated: ?(props: Object, state: Object) => void;
-    shouldUpdate: (props: Object, state: Object) => void;
+    updated: ?(props: Object) => void;
+    shouldUpdate: (props: Object) => void;
     triggerUpdate: () => void;
-    updating: ?(props: Object, state: Object) => void;
+    updating: ?(props: Object) => void;
 
     static _attributeToAttributeMap = {};
     static _attributeToPropertyMap = {};
@@ -150,9 +148,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     static _props = {};
 
     _prevProps = {};
-    _prevState = {};
     _props = {};
-    _state = {};
 
     static get observedAttributes(): Array<string> {
       // We have to define props here because observedAttributes are retrieved
@@ -183,15 +179,6 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     set props(props: Object) {
       const ctorProps = this.constructor.props;
       keys(props).forEach(k => k in ctorProps && ((this: any)[k] = props[k]));
-    }
-
-    get state() {
-      return this._state;
-    }
-
-    set state(state: Object) {
-      this._state = state;
-      this.triggerUpdate();
     }
 
     attributeChangedCallback(
@@ -248,15 +235,14 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
       }
       this._updating = true;
       delay(() => {
-        const { _prevProps, _prevState } = this;
+        const { _prevProps } = this;
         if (this.updating) {
-          this.updating(_prevProps, _prevState);
+          this.updating(_prevProps);
         }
-        if (this.updated && this.shouldUpdate(_prevProps, _prevState)) {
-          this.updated(_prevProps, _prevState);
+        if (this.updated && this.shouldUpdate(_prevProps)) {
+          this.updated(_prevProps);
         }
         this._prevProps = this.props;
-        this._prevState = this.state;
         this._updating = false;
       });
     }


### PR DESCRIPTION
* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Do we _really_ need state?

`this.state` is

* just another prop, one that happens to be called `state`.
* it does not take advantage of the `props` API.
* redundant, we have everything we need using props.
* `state` is extra code that only duplicates a subset of the props functionality.

Contrasting to other libs:

* React uses `this.state` instead of props for reactivity
* Vue uses props instead of state for reactivity.
* Neither use both.

If someone really wants a `state` prop, they can easily add it using `props`:

```js
static props = {
  state: { /* ...  */ }
}

someMethod() {
  this.state = { ...this.state, foo: 'foo' }
}
```

The only thing missing is the `set` helper that merges a subset of props into the whole state so people can write `this.state = { foo: 'foo' }` instead of `this.state = { ...this.state, foo: 'foo' }`.

But, I don't think it's a big deal if we remove this. The premise is that users can define individual props, and set them directly, and don't really need to merge an object.

If we really want to provide this merging feature, it could be another mixin or utility function.

I think it is cleaner just to have `props`.

## Tasks

* [ ] tests
* [ ] docs

