### PR TITLE
Allow attr="false" for boolean attributes

### DIFF
--- a/packages/core/src/props.ts
+++ b/packages/core/src/props.ts
@@ -19,7 +19,7 @@ const array: PropType = {
 const boolean: PropType = {
   ...any,
   deserialize: (val): boolean => val != null,
-  serialize: (val: boolean) => (val ? '' : null)
+  serialize: (val: boolean) => (val && val !== 'false' ? '' : null)
 };
 
 const event: PropType = {


### PR DESCRIPTION


* [ ] Bug
* [x] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

This makes it intuitive to do `some-attribute="false"` for boolean attributes.

## Implementation

Seems like the simplest way, but I haven't tested it yet.

