### PR TITLE
make sure the static cache properties are created per-class

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -134,10 +134,7 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     _prevState: Object;
     _props: Object;
     _state: Object;
-    _syncingAttributeToProperty: null | string;
-    _syncingPropertyToAttribute: boolean;
     _updating: boolean;
-    _wasInitiallyRendered: boolean;
 
     updated: ?(props: Object, state: Object) => void;
     shouldUpdate: (props: Object, state: Object) => void;
@@ -155,6 +152,11 @@ export const withUpdate = (Base: Class<any> = HTMLElement): Class<any> =>
     _state = {};
 
     static get observedAttributes(): Array<string> {
+      // make sure to create a new instance of these static props per constructor.
+      if (!('_attributeToAttributeMap' in this)) this._attributeToAttributeMap = {}
+      if (!('_attributeToPropertyMap' in this)) this._attributeToPropertyMap = {}
+      if (!('_observedAttributes' in this)) this._observedAttributes = []
+
       // We have to define props here because observedAttributes are retrieved
       // only once when the custom element is defined. If we did this only in
       // the constructor, then props would not link to attributes.


### PR DESCRIPTION
make sure the static cache properties are created per-class, instead of shared with all subclasses. Also remove unused properties

issue: https://github.com/skatejs/skatejs/issues/1560

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [x] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Without this change, any subclasses of a base class that uses` withUpdate` will share all `observedAttributes` of all other sub classes (and similar with _attributeToAttributeMap and _attributeToPropertyMap).

## Implementation

I placed the code in `get observedAttributes`, as that's the entry point, triggered by `customElements.define()`. The conditional check is required, because it is possible users and sub classes can also call `get observedAttributes`.
