### PR TITLE
fix: it was impossible to remove `array` or `object` attributes when setting the JS prop to `null`.

### DIFF
--- a/packages/skatejs/src/with-update.js
+++ b/packages/skatejs/src/with-update.js
@@ -276,7 +276,7 @@ const array: Function = prop({
     Array.isArray(val) ? val : empty(val) ? null : [val],
   default: Object.freeze([]),
   deserialize: parse,
-  serialize: stringify
+  serialize: (val: mixed): null | string => (val == null ? null : stringify(val))
 });
 
 const boolean: Function = prop({
@@ -300,7 +300,7 @@ const object: Function = prop({
   attribute,
   default: Object.freeze({}),
   deserialize: parse,
-  serialize: stringify
+  serialize: (val: mixed): null | string => (val == null ? null : stringify(val))
 });
 
 const string: Function = prop({


### PR DESCRIPTION



* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [ ] Wrote tests.
* [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

It is impossible for `prop.serialize` to return null if it simply returns `JSON.stringify(val)`, because a string can not be coerced to `null`, therefore doing something like `this.someProp = null` does not remove the target attribute.

## Implementation

Checks if val is null, and if it is just returns null.

