### PR TITLE
Fix `@skatejs/ssr` in `jsdom` environment

### DIFF
--- a/packages/ssr/index.js
+++ b/packages/ssr/index.js
@@ -17,8 +17,10 @@ function stringify(node) {
     return node.textContent;
   }
 
-  str += `<${node.localName}${(node.attributes || [])
-    .map(a => ` ${a.name}="${a.value}"`)
+  const { map } = Array.prototype;
+
+  str += `<${node.localName}${map
+    .call(node.attributes || [], a => ` ${a.name}="${a.value}"`)
     .join('')}>`;
 
   if (node.nodeName === 'BODY') {
@@ -26,13 +28,13 @@ function stringify(node) {
   }
 
   if (node.shadowRoot) {
-    str += `<shadowroot>${node.shadowRoot.childNodes
-      .map(stringify)
+    str += `<shadowroot>${map
+      .call(node.shadowRoot.childNodes, stringify)
       .join('')}${shadowRootScriptCall}</shadowroot>`;
   }
 
   if (node.childNodes) {
-    str += node.childNodes.map(stringify).join('');
+    str += map.call(node.childNodes, stringify).join('');
   }
 
   str += `</${node.localName}>`;


### PR DESCRIPTION
`NodeList`s don't have a `map` method.
See https://developer.mozilla.org/en-US/docs/Web/API/NodeList

_If there is a linked issue, mention it here._

* [x] Bug
* [ ] Feature

## Requirements

* [x] Read the [contribution guidelines](https://github.com/skatejs/skatejs/blob/master/CONTRIBUTING.md).
* [x] Wrote tests.
* [x] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

`NodeList`s don't have a `map` method.
See https://developer.mozilla.org/en-US/docs/Web/API/NodeList

I have existing tests using `undom` but I've had a lot of luck switching over to https://github.com/SimenB/jest-environment-jsdom-sixteen (see https://github.com/jsdom/jsdom/releases/tag/16.2.0).

## Implementation

_Why have you implemented it this way? Did you try any other methods?_

I considered using Array spread or `Array.from` but went with this approach to avoid creating arrays. Happy to change the implementation for terseness though.

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other

_Is there anything else we should know? Delete this section if you don't need it._

I've tested both this approach (as well as using Array spread) in my project via https://github.com/ds300/patch-package and everything works.